### PR TITLE
GF3D PR 4 - Public API, C binding, Python Module + Python/Fortran API demos for the globe example

### DIFF
--- a/EXAMPLES/green_function_database/README.md
+++ b/EXAMPLES/green_function_database/README.md
@@ -75,6 +75,97 @@ SPECFEM3D_GLOBE and validate it against direct forward simulations.
    already finished is repeated.
 
 
+## Calling the library yourself
+
+Everything above goes through `xgf3d` and writes files. For an inversion,
+what you want instead is the seismograms and their partial derivatives in
+memory. The library is callable directly from Python and from Fortran, and
+`global/` holds a pair of runnable demonstrations of each — four short
+programs against the database the global workflow builds. They are not part
+of the workflow: nothing in either `Snakefile` refers to those directories,
+so run them by hand once `global/GFDB` exists.
+
+All four need `lib/libgf3d.so`, which comes from `make gf3d` in a tree
+configured `--with-hdf5`.
+
+### Python
+
+The `gf3d` package is a ctypes binding, so it needs no compiler:
+
+```python
+import gf3d
+
+with gf3d.Database("global/GFDB") as db:
+    cmt = gf3d.CMTSource.read("global/validation_data/CMTSOLUTION")
+    r = db.partials(cmt)
+
+    r.data        # (nstations, 3, nt) metres, components N, E, Z
+    r.t           # (nt,) seconds, t = 0 at the centroid time
+    r.dp          # (nstations, 10, 3, nt) partial derivatives
+    r.dp_names    # ['Mrr', ..., 'Mtp', 'lat', 'lon', 'dep', 'tim']
+```
+
+`global/api_demos/python/` holds two scripts. Each writes one figure and nothing
+else, and reports how long every call into the library took.
+
+```bash
+cd global/api_demos/python
+../../../.venv/bin/python gf3d_api_demo.py       # the partials, and what they are for
+../../../.venv/bin/python gf3d_events_demo.py    # several events from one open database
+```
+
+`gf3d_api_demo.py` opens the database, extracts seismograms and all ten
+partial derivatives, checks the identity the moment-tensor partials satisfy
+exactly, and then uses a centroid partial as a derivative: it predicts the
+seismogram of a relocated source from a single Taylor term and shows the
+error falling fourfold each time the relocation is halved, which is what a
+correct first derivative must do and a plausible-looking wrong one will
+not.
+
+`gf3d_events_demo.py` is the catalogue case. The database was not built for
+one earthquake — `db_base/DATA/GF_LOCATIONS` declares three hypocentres,
+and the reciprocal runs stored the strain around all of them — so the
+script opens the database once and extracts for every hypocentre it
+declares. The timings are the point: tens of milliseconds per event against
+the forty minutes of simulation that built the database.
+
+See `utils/green_function/gf3d/README.md` for the package itself.
+
+### Fortran
+
+A Fortran program needs `use gf3d` and nothing else. `global/api_demos/fortran/`
+holds the same two demonstrations, without the figures:
+
+```bash
+cd global/api_demos/fortran
+make                     # or: make FC=ifort
+./gf3d_api_demo
+./gf3d_events_demo
+```
+
+They print the same numbers as their Python counterparts, because it is the
+same library underneath.
+
+The link line is worth reading, in `global/api_demos/fortran/Makefile`:
+
+```
+$(FC) demo.f90 -I<repo>/include -L<repo>/lib -lgf3d -Wl,-rpath,<repo>/lib
+```
+
+and that is all of it. No HDF5 flags and no list of the shared objects the
+library reuses: `lib/libgf3d.so` records HDF5 as a dependency of its own and
+the `-rpath` lets the loader find it, so a caller does not have to know
+where this tree's HDF5 came from. Linking the static `lib/libgf3d.a` works
+too and is what `tests/gf3d/` does, but then the HDF5 link line becomes the
+caller's problem.
+
+One thing to know: Fortran module files are compiler-specific, so
+`include/gf3d.mod` can only be read by the compiler that wrote it — the one
+the tree was configured with. The Makefile defaults to `gfortran`; if that
+is not what built the library you will get `Cannot open module file
+'gf3d.mod'`, and `make FC=<yours>` is the fix.
+
+
 ## Workflow Configuration
 
 The Snakefile accepts configuration overrides via `--config`. Key options:

--- a/EXAMPLES/green_function_database/global/api_demos/fortran/.gitignore
+++ b/EXAMPLES/green_function_database/global/api_demos/fortran/.gitignore
@@ -1,0 +1,2 @@
+gf3d_api_demo
+gf3d_events_demo

--- a/EXAMPLES/green_function_database/global/api_demos/fortran/Makefile
+++ b/EXAMPLES/green_function_database/global/api_demos/fortran/Makefile
@@ -1,0 +1,79 @@
+#=====================================================================
+#
+# Two demonstrations of calling libgf3d from Fortran.
+#
+#     make            build both
+#     make FC=ifort   build with another compiler (see the note below)
+#     make clean
+#
+# then
+#
+#     ./gf3d_api_demo
+#     ./gf3d_events_demo
+#
+# The link line is the whole point, so it is worth reading:
+#
+#     $(FC) demo.f90 -I<repo>/include -L<repo>/lib -lgf3d -Wl,-rpath,<repo>/lib
+#
+# and that is all. No HDF5 flags, no list of the shared objects the library
+# reuses: lib/libgf3d.so records HDF5 as a dependency of its own, and the
+# -rpath means the loader can find it without LD_LIBRARY_PATH being set.
+#
+# Linking lib/libgf3d.a instead works too, and is what tests/gf3d does, but
+# then HDF5 becomes the caller's problem -- an archive carries undefined
+# symbols and no idea where to satisfy them.
+#
+# A note on FC. Fortran module files are compiler-specific and often
+# version-specific, so <repo>/include/gf3d.mod can only be read by the
+# compiler that wrote it -- the one the tree was configured with. If the
+# default below is not that compiler you will get "Cannot open module file
+# 'gf3d.mod'", which is unambiguous; pass FC= to fix it.
+#
+#=====================================================================
+
+# the top of the specfem3d_globe tree, from here
+SPECFEM_DIR ?= ../../../../..
+
+# `FC ?= gfortran` would not work: make has a built-in default for FC (f77),
+# so FC is always already defined and ?= never fires. Overriding only when
+# the value is that built-in leaves `make FC=ifort` and an FC exported in
+# the environment both working.
+ifeq ($(origin FC),default)
+  FC = gfortran
+endif
+
+# kept separate from FCFLAGS because the HDF5 environment modules on some
+# systems export an include path there, and it should not displace this
+OPT ?= -O2
+
+INCDIR = $(SPECFEM_DIR)/include
+LIBDIR = $(SPECFEM_DIR)/lib
+
+# absolute, because an -rpath is resolved by the loader at run time and has
+# no idea what the working directory was at build time
+LIBDIR_ABS = $(abspath $(LIBDIR))
+
+GF3D_FLAGS = -I$(INCDIR) -L$(LIBDIR) -lgf3d -Wl,-rpath,$(LIBDIR_ABS)
+
+PROGRAMS = gf3d_api_demo gf3d_events_demo
+
+all: $(PROGRAMS)
+
+$(PROGRAMS): %: %.f90 $(LIBDIR)/libgf3d.so $(INCDIR)/gf3d.mod
+	$(FC) $(OPT) $(FCFLAGS) $< -o $@ $(GF3D_FLAGS)
+
+# A clearer failure than "no rule to make target" when the library has not
+# been built yet.
+$(LIBDIR)/libgf3d.so $(INCDIR)/gf3d.mod:
+	@echo ""
+	@echo "$@ is missing: libgf3d has not been built."
+	@echo "From the top of the tree ($(SPECFEM_DIR)):"
+	@echo "    ./configure --with-hdf5 HDF5_INC=<dir> HDF5_LIBS=-L<dir>"
+	@echo "    make gf3d"
+	@echo ""
+	@false
+
+clean:
+	rm -f $(PROGRAMS) *.mod *.o
+
+.PHONY: all clean

--- a/EXAMPLES/green_function_database/global/api_demos/fortran/gf3d_api_demo.f90
+++ b/EXAMPLES/green_function_database/global/api_demos/fortran/gf3d_api_demo.f90
@@ -1,0 +1,504 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- A runnable tour of the gf3d Fortran API, on the global example.
+!----
+!---- The Python counterpart of this program is
+!---- ../python/gf3d_api_demo.py; it prints the same numbers, because it
+!---- drives the same library. This one is what a Fortran caller sees:
+!----
+!----     use gf3d
+!----
+!---- and nothing else. Everything below -- the types, the routines, the
+!---- error codes, the names and units of the partial derivatives -- comes
+!---- from that one module. If it did not, this program would not compile,
+!---- which is rather the point of writing it.
+!----
+!---- Build (see the Makefile):
+!----
+!----     gfortran gf3d_api_demo.f90 -I<repo>/include \
+!----              -L<repo>/lib -lgf3d -Wl,-rpath,<repo>/lib
+!----
+!---- No HDF5 flags: lib/libgf3d.so records HDF5 as a dependency of its own
+!---- and carries the library path with it, so a caller does not have to
+!---- know where this tree's HDF5 came from. Linking the static
+!---- lib/libgf3d.a instead works too, but then the full HDF5 link line is
+!---- the caller's problem.
+!----
+!---- Five sections, each printing what it measured:
+!----
+!----   1. open the database and say what is in it
+!----   2. read a CMTSOLUTION and locate it in the mesh
+!----   3. plan the output axis and the source time function conversion
+!----   4. extract seismograms and their ten partial derivatives
+!----   5. use a centroid partial as a derivative, and show it converges
+!----
+!---- Section 5 is the one worth reading. Sections 1 to 4 can be had from
+!---- bin/xgf3d and a pile of SAC files; what the library is for is section
+!---- 5, where the partials are Frechet derivatives to be used rather than
+!---- traces to be written.
+!----
+
+  program gf3d_api_demo
+
+  use gf3d
+
+  implicit none
+
+  ! paths, relative to this directory
+  character(len=*), parameter :: DB_PATH = '../../GFDB'
+  character(len=*), parameter :: CMT_PATH = '../../validation_data/CMTSOLUTION'
+
+  ! the relocation used in section 5, in degrees of latitude, and how many
+  ! times it is halved
+  double precision, parameter :: STEP0 = 0.05d0
+  integer, parameter :: NHALVE = 2
+
+  type(t_gfdb) :: db
+  type(t_gf_source) :: src,moved
+  type(t_gf_location) :: loc
+  type(t_gf_taxis) :: tax
+  type(t_gf_stf) :: stf
+
+  double precision, dimension(:,:,:), allocatable :: synt,truth
+  double precision, dimension(:,:,:,:), allocatable :: dp
+  double precision, dimension(:), allocatable :: t
+
+  ! scratch outputs for the itypsokern = 0 calls of section 5: they are
+  ! allocated zero-sized and never read, but get_seismograms allocates
+  ! through them, so they have to be variables rather than expressions
+  double precision, dimension(:,:,:,:), allocatable :: dp_unused
+  double precision, dimension(:), allocatable :: t_unused
+
+  double precision :: t_open,t_locate,t_locate2,t_extract,t_total
+  double precision, dimension(0:NHALVE) :: t_reloc,step,err
+  double precision :: peak,worst,ratio
+  integer :: ierr,i,ista,icomp,ip,k,nsta,nt
+
+  character(len=34) :: label
+
+  ! for tic()/toc(), by host association. Both are integer(8) so that
+  ! system_clock reports nanoseconds rather than milliseconds -- some of
+  ! the calls below take well under one of the latter.
+  integer(kind=8) :: clock_start,clock_rate
+
+  logical :: ok
+
+  ok = .true.
+  t_total = 0.d0
+
+  write(*,*)
+  write(*,*) '========================================================'
+  write(*,*) ' gf3d Fortran API demonstration'
+  write(*,*) '========================================================'
+  write(*,'(a,a)') '  library version : ',trim(GF3D_VERSION)
+
+!
+!--- 1. the database ---------------------------------------------------
+!
+
+  call banner('1. the database')
+
+  ! check_completion = .false. skips verifying that every element/station
+  ! file the index promises is actually present. That check is one stat()
+  ! per file -- 328 of them here, about half a second -- and is what
+  ! `xgf3d --info` does; an extraction does not need it.
+  call tic()
+  call gf_open(DB_PATH,db,ierr,check_completion = .false.)
+  call toc(t_open)
+
+  if (ierr /= GF_OK) then
+    write(*,*)
+    write(*,'(a,a)') '  could not open ',DB_PATH
+    write(*,'(a,a)') '  ',trim(gf_errmsg)
+    write(*,*)
+    write(*,*) '  The example database is built by the workflow, and is'
+    write(*,*) '  gitignored. From EXAMPLES/green_function_database/global:'
+    write(*,*) '      snakemake -j1'
+    stop 1
+  endif
+
+  write(*,'(a,f9.1,a)') '  gf_open took ',t_open*1.d3,' ms (metadata only;' // &
+                        ' elements are read on demand)'
+  write(*,*)
+
+  ! straight out of the handle: this is what a caller reads
+  write(*,'(a,a)')                '  path             : ',trim(db%path)
+  write(*,'(a,i0)')               '  elements         : ',db%nelem
+  write(*,'(a,i0,a,i0,a)')        '  stored samples   : ',db%nt_subsampled, &
+                                  ' of ',db%nstep,' solver steps'
+  write(*,'(a,f6.3,a,i0,a,f7.3,a)') '  sample spacing   : ',db%dt,' s x ', &
+                                  db%subsample_step,' = ', &
+                                  db%dt*dble(db%subsample_step),' s'
+  write(*,'(a,l1,a,l1,a,l1)')     '  topography       : ',db%topography, &
+                                  '   ellipticity ',db%ellipticity, &
+                                  '   rotation ',db%rotation
+  write(*,'(a,i0)')               '  stations         : ',db%nstations
+
+  write(*,*)
+  write(*,'(a)') '    station         latitude    longitude   burial [m]'
+  do i = 1,db%nstations
+    write(*,'(a,a12,2f13.4,f12.1)') '    ',trim(db%stations(i)%id), &
+      db%stations(i)%latitude,db%stations(i)%longitude,db%stations(i)%depth
+  enddo
+
+  write(*,*)
+  write(*,*) '  (gf_print_info(db,6,.false.) prints all of the metadata,'
+  write(*,*) '   which is what `xgf3d --info` shows)'
+
+  nsta = db%nstations
+
+!
+!--- 2. the source ------------------------------------------------------
+!
+
+  call banner('2. the source, and where it sits')
+
+  ! The file route. A Fortran caller may use the solver's own CMTSOLUTION
+  ! reader directly -- it is re-exported here -- where the C and Python
+  ! interfaces deliberately cannot, because get_cmt() stops on malformed
+  ! input and a stop inside a shared object would kill the caller. Reading
+  ! the file is safe from a program that owns its own process.
+  call gf_read_cmt_source(CMT_PATH,db%dt,src,ierr)
+  if (ierr /= GF_OK) then
+    write(*,'(a,a)') '  could not read the CMTSOLUTION: ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  call gf_print_source(src,6)
+
+  call tic()
+  call gf_locate_source(db,src%latitude,src%longitude,src%depth,loc,ierr)
+  call toc(t_locate)
+
+  if (ierr /= GF_OK) then
+    write(*,'(a,a)') '  could not locate the source: ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  ! again, to show what the first one paid for
+  call tic()
+  call gf_locate_source(db,src%latitude,src%longitude,src%depth,loc,ierr)
+  call toc(t_locate2)
+
+  write(*,*)
+  write(*,'(a,i0,a,a)')   '  element        : ',loc%ielem,'  ',trim(loc%morton_hex)
+  write(*,'(a,3f14.9)')   '  xi, eta, gamma : ',loc%xi,loc%eta,loc%gamma
+  write(*,'(a,es12.4,a)') '  |mapped - requested| : ',loc%distance_km,' km'
+  write(*,'(a,es12.4)')   '  27-anchor residual   : ',loc%anchor_err
+  write(*,'(a,f9.1,a)')   '  gf_locate_source took ',t_locate*1.d3, &
+                          ' ms the first time,'
+  write(*,'(a,f9.1,a)')   '                        ',t_locate2*1.d3, &
+                          ' ms the second'
+  write(*,*) '  (the first call builds the element search tree and loads the'
+  write(*,*) '   topography grid; every later one reuses both)'
+
+  if (max(abs(loc%xi),abs(loc%eta),abs(loc%gamma)) > 1.d0) then
+    write(*,*)
+    write(*,*) '  Note: one coordinate is outside [-1,1], so the source sits'
+    write(*,*) '  just outside the element that holds it. That is not a bug:'
+    write(*,*) '  it is where specfem itself placed this source, and'
+    write(*,*) '  reproducing that run is what the extraction is judged on.'
+  endif
+
+!
+!--- 3. the plan --------------------------------------------------------
+!
+
+  call banner('3. the output axis and the source time function')
+
+  call gf_seis_plan(db,src,-1.d0,tax,stf,ierr)
+  if (ierr /= GF_OK) then
+    write(*,'(a,a)') '  could not plan: ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  ! -1 above asks for specfem's own rule for a forward run, 1.5*hdur before
+  ! the centroid time for a moment tensor. Pass a positive number to choose.
+  call gf_print_stf(stf,tax,6)
+
+  nt = tax%nt
+
+!
+!--- 4. extraction ------------------------------------------------------
+!
+
+  call banner('4. seismograms and partial derivatives')
+
+  ! get_seismograms() is GF3DF's name and argument shape: it locates, plans
+  ! and extracts in one call, and allocates its own outputs. itypsokern = 2
+  ! asks for all ten partials; 1 gives the six moment-tensor ones, 0 none.
+  call tic()
+  call get_seismograms(db,src,synt,dp,2,t,ierr)
+  call toc(t_extract)
+
+  if (ierr /= GF_OK) then
+    write(*,'(a,a)') '  extraction failed: ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  write(*,'(a,f9.1,a)') '  get_seismograms took ',t_extract*1.d3,' ms'
+  write(*,*)
+  write(*,'(a,i0,a,i0,a,i0,a)') '  synt(', size(synt,1),',',size(synt,2),',', &
+                                size(synt,3),')   stations, components N/E/Z, samples'
+  write(*,'(a,i0,a,i0,a,i0,a,i0,a)') '  dp  (', size(dp,1),',',size(dp,2),',', &
+                                size(dp,3),',',size(dp,4),')  parameters first'
+  write(*,'(a,i0,a,f12.4,a,f12.4,a)') '  t   (',size(t),')   from ',t(1), &
+                                ' s to ',t(size(t)),' s'
+  write(*,*) '  (t = 0 is the centroid time: the CMTSOLUTION time shift is'
+  write(*,*) '   header metadata and is not in the trace)'
+
+  write(*,*)
+  write(*,*) '  peak displacement per station and component [m]'
+  write(*,'(a)') '      station               N            E            Z'
+  do ista = 1,nsta
+    write(*,'(a,a12,3es13.4)') '    ',adjustr(db%stations(ista)%id(1:12)), &
+      (maxval(abs(synt(ista,icomp,:))),icomp = 1,3)
+  enddo
+
+  write(*,*)
+  write(*,*) '  the ten partials, their units, and their peaks'
+  do ip = 1,GF_NDP_LOC
+    write(*,'(a,i2,a,a3,a,a9,a,es12.4)') '    ',ip,'   ',GF_DP_NAME(ip), &
+      '   ',GF_DP_UNIT(ip),'   ',maxval(abs(dp(ip,:,:,:)))
+  enddo
+
+  ! -- the identity the moment-tensor partials satisfy --------------------
+  !
+  ! The first six are per dyne-cm and the seismogram is linear in the moment
+  ! tensor, so contracting them with the CMTSOLUTION's own components has to
+  ! give the seismogram back. src%moment_tensor is non-dimensional --
+  ! get_cmt divided by scaleM -- so scale_moment puts it back into dyne-cm.
+  worst = 0.d0
+  peak = maxval(abs(synt))
+  do ista = 1,nsta
+    do icomp = 1,3
+      do i = 1,nt
+        worst = max(worst,abs(sum(src%moment_tensor(1:6)*src%scale_moment &
+                                  *dp(1:6,ista,icomp,i)) - synt(ista,icomp,i)))
+      enddo
+    enddo
+  enddo
+
+  write(*,*)
+  write(*,*) '  sum over v of M_v * dp(v) against the seismogram:'
+  write(*,'(a,es12.4,a)') '    max difference ',worst/peak,' of the trace peak'
+  write(*,*) '  So a new mechanism at the same hypocentre is a contraction of'
+  write(*,*) '  arrays already in memory, not another extraction.'
+
+  if (worst/peak > 1.d-12) ok = .false.
+
+!
+!--- 5. the centroid partials are derivatives ---------------------------
+!
+
+  call banner('5. the centroid partials are derivatives')
+
+  write(*,*) '  Relocating the source changes the seismogram non-linearly, so'
+  write(*,*) '  here the partial is a genuine derivative and one Taylor term'
+  write(*,*) '  is only an approximation:'
+  write(*,*)
+  write(*,*) '      u(lat + h)  ~=  u(lat) + h * du/dlat'
+  write(*,*)
+  write(*,*) '  Its error must fall as h^2, so halving h divides the error by'
+  write(*,*) '  four. A partial with the wrong sign, units or scaling cannot'
+  write(*,*) '  do that, however plausible its traces look.'
+  write(*,*)
+
+  do k = 0,NHALVE
+    step(k) = STEP0 / dble(2**k)
+
+    moved = src
+    moved%latitude = src%latitude + step(k)
+
+    call tic()
+    call get_seismograms(db,moved,truth,dp_unused,0,t_unused,ierr)
+    call toc(t_reloc(k))
+
+    if (ierr /= GF_OK) then
+      write(*,'(a,f9.4,a,a)') '    step ',step(k),' could not be extracted: ', &
+        trim(gf_error_string(ierr))
+      write(*,*) '    (the relocated source left the database)'
+      err(k) = -1.d0
+      cycle
+    endif
+
+    ! predicted from the *unperturbed* run: synt + h * dp(lat)
+    err(k) = 0.d0
+    do ista = 1,nsta
+      do icomp = 1,3
+        do i = 1,nt
+          err(k) = max(err(k),abs(synt(ista,icomp,i) &
+                   + step(k)*dp(GF_DP_LAT,ista,icomp,i) - truth(ista,icomp,i)))
+        enddo
+      enddo
+    enddo
+    err(k) = err(k)/peak
+
+    deallocate(truth)
+  enddo
+
+  write(*,'(a)') '      step [deg]    error / peak    ratio'
+  do k = 0,NHALVE
+    if (err(k) < 0.d0) cycle
+    if (k > 0 .and. err(max(k-1,0)) > 0.d0) then
+      ratio = err(k-1)/err(k)
+      write(*,'(a,f11.5,es16.4,f10.2)') '    ',step(k),err(k),ratio
+    else
+      write(*,'(a,f11.5,es16.4)') '    ',step(k),err(k)
+    endif
+  enddo
+
+  if (err(0) > 0.d0 .and. err(NHALVE) > 0.d0) then
+    ratio = (err(0)/err(NHALVE))**(1.d0/dble(NHALVE))
+    write(*,*)
+    if (ratio > 3.d0 .and. ratio < 5.d0) then
+      write(*,'(a,f5.2,a)') '  mean ratio ',ratio, &
+        ': second order, as a first derivative must be'
+    else
+      write(*,'(a,f5.2,a)') '  mean ratio ',ratio, &
+        ': NOT second order -- something is wrong'
+      ok = .false.
+    endif
+  endif
+
+!
+!--- timings ------------------------------------------------------------
+!
+
+  call banner('timings')
+
+  t_total = t_open + t_locate + t_locate2 + t_extract + sum(t_reloc)
+
+  call timing_line('gf_open',t_open)
+  call timing_line('gf_locate_source, first',t_locate)
+  call timing_line('gf_locate_source, again',t_locate2)
+  call timing_line('get_seismograms, 10 partials',t_extract)
+  do k = 0,NHALVE
+    write(label,'(a,f7.4,a)') 'get_seismograms, at +',step(k),' deg'
+    call timing_line(label,t_reloc(k))
+  enddo
+  write(*,'(a)') '                                    ----------'
+  call timing_line('in the library',t_total)
+  write(*,*)
+  write(*,'(a,i0,a,i0,a)') '  Every extraction above produced ',nsta, &
+    ' stations x 3 components x ',nt,' samples.'
+  write(*,*) '  The database is opened once and stays open; the reciprocal'
+  write(*,*) '  simulations that built it took about forty minutes.'
+
+!
+!--- done ---------------------------------------------------------------
+!
+
+  deallocate(synt,dp,t)
+
+  ! the pair a long-lived caller needs: gf_close alone leaves the search
+  ! tree allocated, because gf_locate cannot be unwound from gf_database
+  call gf_release(db)
+
+  write(*,*)
+  if (ok) then
+    write(*,*) 'gf3d_api_demo: done'
+  else
+    write(*,*) 'gf3d_api_demo: something did not agree, see above'
+    stop 1
+  endif
+  write(*,*)
+
+  contains
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine timing_line(label,seconds)
+
+! one row of the timing table, in a fixed column
+
+  implicit none
+
+  character(len=*), intent(in) :: label
+  double precision, intent(in) :: seconds
+
+  ! local parameters
+  character(len=34) :: padded
+
+  padded = label
+
+  write(*,'(a,a,f10.1,a)') '  ',padded,seconds*1.d3,' ms'
+
+  end subroutine timing_line
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine banner(title)
+
+  implicit none
+
+  character(len=*), intent(in) :: title
+
+  write(*,*)
+  write(*,'(a,a)') ' ',title
+  write(*,'(a,a)') ' ',repeat('-',len_trim(title))
+
+  end subroutine banner
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine tic()
+
+  implicit none
+
+  call system_clock(clock_start,clock_rate)
+
+  end subroutine tic
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine toc(seconds)
+
+  implicit none
+
+  double precision, intent(out) :: seconds
+
+  ! local parameters
+  integer(kind=8) :: clock_end
+
+  call system_clock(clock_end)
+
+  seconds = dble(clock_end - clock_start)/dble(clock_rate)
+
+  end subroutine toc
+
+  end program gf3d_api_demo

--- a/EXAMPLES/green_function_database/global/api_demos/fortran/gf3d_events_demo.f90
+++ b/EXAMPLES/green_function_database/global/api_demos/fortran/gf3d_events_demo.f90
@@ -1,0 +1,367 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- Seismograms for several events from one open database.
+!----
+!---- The Fortran counterpart of ../python/gf3d_events_demo.py.
+!----
+!---- The global example's database was not built for a single earthquake.
+!---- Its db_base/DATA/GF_LOCATIONS names three hypocentres -- the 2010
+!---- Chile (Maule) event, the 2019 Peru event, and a point near the centre
+!---- of the chunk -- and the reciprocal runs stored the strain around all
+!---- of them. That is what a Green function database is for: the expensive
+!---- simulations are done per *station*, once, and any source inside the
+!---- covered volume is then a look-up.
+!----
+!---- So this program opens the database once and extracts for every
+!---- hypocentre the database itself declares, timing each, and prints the
+!---- peak amplitudes. The moment tensor is held fixed at the validation
+!---- event's, so the three records differ only by where the source sits.
+!---- A real catalogue would vary the mechanism too, and that costs nothing
+!---- extra: the moment-tensor partials are exact, so a new mechanism at the
+!---- same hypocentre is a contraction of arrays already in memory rather
+!---- than another extraction. gf3d_api_demo shows that identity.
+!----
+
+  program gf3d_events_demo
+
+  use gf3d
+
+  implicit none
+
+  character(len=*), parameter :: DB_PATH = '../../GFDB'
+  character(len=*), parameter :: CMT_PATH = '../../validation_data/CMTSOLUTION'
+  character(len=*), parameter :: LOC_PATH = '../../db_base/DATA/GF_LOCATIONS'
+
+  integer, parameter :: MAX_EVENTS = 64
+
+  type(t_gfdb) :: db
+  type(t_gf_source) :: src,event
+  type(t_gf_location) :: loc
+
+  double precision, dimension(:,:,:), allocatable :: synt
+  double precision, dimension(:,:,:,:), allocatable :: dp_unused
+  double precision, dimension(:), allocatable :: t
+
+  ! the hypocentres, as GF_LOCATIONS gives them
+  character(len=64), dimension(MAX_EVENTS) :: ev_name
+  double precision, dimension(MAX_EVENTS) :: ev_lat,ev_lon,ev_dep
+  integer :: nev
+
+  ! what each one measured
+  double precision, dimension(MAX_EVENTS) :: t_locate,t_extract,peak
+  double precision, dimension(:,:), allocatable :: peak_sta
+  integer, dimension(MAX_EVENTS) :: ielem
+  logical, dimension(MAX_EVENTS) :: done
+
+  character(len=32) :: hdr
+
+  double precision :: t_open,sum_extract
+  integer :: ierr,k,ista,nsta,nt,nok
+
+  integer(kind=8) :: clock_start,clock_rate
+
+  write(*,*)
+  write(*,*) '========================================================'
+  write(*,*) ' gf3d: several events, one open database'
+  write(*,*) '========================================================'
+  write(*,'(a,a)') '  library version : ',trim(GF3D_VERSION)
+
+!
+!--- the hypocentres the database declares ------------------------------
+!
+
+  call read_locations(LOC_PATH,ev_name,ev_lat,ev_lon,ev_dep,nev,ierr)
+  if (ierr /= 0) then
+    write(*,'(a,a)') '  could not read ',LOC_PATH
+    stop 1
+  endif
+  if (nev < 1) then
+    write(*,'(a,a)') '  no hypocentres declared in ',LOC_PATH
+    stop 1
+  endif
+
+  write(*,'(a,i0,a,a)') '  events          : ',nev,' from ',LOC_PATH
+
+!
+!--- open, once ---------------------------------------------------------
+!
+
+  call tic()
+  call gf_open(DB_PATH,db,ierr,check_completion = .false.)
+  call toc(t_open)
+
+  if (ierr /= GF_OK) then
+    write(*,*)
+    write(*,'(a,a)') '  could not open ',DB_PATH
+    write(*,'(a,a)') '  ',trim(gf_errmsg)
+    write(*,*)
+    write(*,*) '  The example database is built by the workflow, and is'
+    write(*,*) '  gitignored. From EXAMPLES/green_function_database/global:'
+    write(*,*) '      snakemake -j1'
+    stop 1
+  endif
+
+  nsta = db%nstations
+  allocate(peak_sta(nev,nsta))
+  peak_sta(:,:) = 0.d0
+
+  write(*,'(a,i0,a,10(a,a))') '  stations        : ',nsta,':  ', &
+    (trim(db%stations(ista)%id),'  ',ista = 1,min(nsta,10))
+  write(*,'(a,f9.1,a)') '  gf_open took ',t_open*1.d3,' ms'
+
+!
+!--- the mechanism, from the validation event ---------------------------
+!
+
+  call gf_read_cmt_source(CMT_PATH,db%dt,src,ierr)
+  if (ierr /= GF_OK) then
+    write(*,'(a,a)') '  could not read the CMTSOLUTION: ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  write(*,'(a,a,a)') '  mechanism held fixed at ',trim(src%event_name), &
+                     '''s, so only the hypocentre differs'
+
+!
+!--- one extraction per hypocentre --------------------------------------
+!
+
+  ! a left-justified header: Fortran right-justifies a character value in a
+  ! wider aW field, which would put this over the numbers instead
+  hdr = 'event'
+
+  write(*,*)
+  write(*,'(a,a32,3a11,a7,2a11,a13)') '  ',hdr,'lat','lon','depth', &
+    'elem','locate','extract','peak [m]'
+  write(*,'(a)') '  ' // repeat('-',107)
+
+  nok = 0
+  nt = 0
+
+  do k = 1,nev
+    done(k) = .false.
+
+    ! same source, moved. t_gf_source is a plain derived type, so this is
+    ! the whole of "make me another event at a different place".
+    event = src
+    event%latitude = ev_lat(k)
+    event%longitude = ev_lon(k)
+    event%depth = ev_dep(k)
+
+    call tic()
+    call gf_locate_source(db,ev_lat(k),ev_lon(k),ev_dep(k),loc,ierr)
+    call toc(t_locate(k))
+
+    if (ierr /= GF_OK) then
+      write(*,'(a,a32,3f11.3,a,a)') '  ',ev_name(k),ev_lat(k),ev_lon(k),ev_dep(k), &
+        '      -- ',trim(gf_error_string(ierr))
+      cycle
+    endif
+
+    ! itypsokern = 0: seismograms only, no partials
+    call tic()
+    call get_seismograms(db,event,synt,dp_unused,0,t,ierr)
+    call toc(t_extract(k))
+
+    if (ierr /= GF_OK) then
+      write(*,'(a,a32,3f11.3,a,a)') '  ',ev_name(k),ev_lat(k),ev_lon(k),ev_dep(k), &
+        '      -- ',trim(gf_error_string(ierr))
+      cycle
+    endif
+
+    ielem(k) = loc%ielem
+    peak(k) = maxval(abs(synt))
+    do ista = 1,nsta
+      peak_sta(k,ista) = maxval(abs(synt(ista,:,:)))
+    enddo
+    nt = size(t)
+    done(k) = .true.
+    nok = nok + 1
+
+    write(*,'(a,a32,3f11.3,i7,f8.1,a,f8.1,a,es13.4)') '  ',ev_name(k), &
+      ev_lat(k),ev_lon(k),ev_dep(k),ielem(k), &
+      t_locate(k)*1.d3,' ms',t_extract(k)*1.d3,' ms',peak(k)
+
+    deallocate(synt,t)
+    if (allocated(dp_unused)) deallocate(dp_unused)
+  enddo
+
+  if (nok == 0) then
+    write(*,*)
+    write(*,*) '  none of the declared hypocentres is inside this database'
+    call gf_release(db)
+    stop 1
+  endif
+
+!
+!--- peaks per station --------------------------------------------------
+!
+
+  write(*,*)
+  write(*,*) '  peak amplitude per station [m]'
+  write(*,'(a,a32,10a14)') '    ',hdr, &
+    (trim(db%stations(ista)%id),ista = 1,nsta)
+  do k = 1,nev
+    if (.not. done(k)) cycle
+    write(*,'(a,a32,10es14.4)') '    ',ev_name(k),(peak_sta(k,ista),ista = 1,nsta)
+  enddo
+
+!
+!--- what it cost -------------------------------------------------------
+!
+
+  sum_extract = 0.d0
+  do k = 1,nev
+    if (done(k)) sum_extract = sum_extract + t_extract(k)
+  enddo
+
+  write(*,*)
+  write(*,'(a,i0,a,f6.1,a)') '  ',nok,' events: ',t_open*1.d3,' ms to open,'
+  write(*,'(a,f6.1,a)')      '  ',t_locate(1)*1.d3, &
+    ' ms for the first locate (it builds the element search'
+  write(*,*) '  tree and loads the topography grid), then'
+  write(*,'(a,f6.1,a,i0,a,i0,a)') '  ',sum_extract*1.d3/dble(nok), &
+    ' ms per event on average, each ',nsta,' stations x 3 components x ',nt, &
+    ' samples.'
+  write(*,*)
+  write(*,*) '  The reciprocal simulations that built this database took about'
+  write(*,*) '  forty minutes. Every source inside it is now a look-up.'
+
+  deallocate(peak_sta)
+
+  call gf_release(db)
+
+  write(*,*)
+  write(*,*) 'gf3d_events_demo: done'
+  write(*,*)
+
+  contains
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine read_locations(filename,name,lat,lon,dep,n,ierr)
+
+! the hypocentres a GF_LOCATIONS file declares, with their labels
+!
+! Three columns -- latitude longitude depth_km -- with `#` comments. The
+! comment immediately above a row is taken as that row's name, which is how
+! the shipped file labels its events.
+
+  implicit none
+
+  character(len=*), intent(in) :: filename
+  character(len=64), dimension(:), intent(out) :: name
+  double precision, dimension(:), intent(out) :: lat,lon,dep
+  integer, intent(out) :: n,ierr
+
+  ! local parameters
+  integer, parameter :: IIN_LOC = 71
+  character(len=256) :: line
+  character(len=64) :: label
+  integer :: ios
+  double precision :: a,b,c
+
+  n = 0
+  ierr = 0
+  label = ''
+
+  open(unit=IIN_LOC,file=trim(filename),status='old',action='read',iostat=ios)
+  if (ios /= 0) then
+    ierr = 1
+    return
+  endif
+
+  do
+    read(IIN_LOC,'(a)',iostat=ios) line
+    if (ios /= 0) exit
+
+    line = adjustl(line)
+    if (len_trim(line) == 0) cycle
+
+    if (line(1:1) == '#') then
+      ! remember it: if a data row follows, this is its name
+      label = adjustl(line(2:))
+      cycle
+    endif
+
+    read(line,*,iostat=ios) a,b,c
+    if (ios /= 0) cycle
+
+    if (n >= size(lat)) exit
+
+    n = n + 1
+    lat(n) = a
+    lon(n) = b
+    dep(n) = c
+    if (len_trim(label) > 0) then
+      name(n) = label
+    else
+      write(name(n),'(a,i0)') 'event ',n
+    endif
+    label = ''
+  enddo
+
+  close(IIN_LOC)
+
+  end subroutine read_locations
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine tic()
+
+  implicit none
+
+  call system_clock(clock_start,clock_rate)
+
+  end subroutine tic
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine toc(seconds)
+
+  implicit none
+
+  double precision, intent(out) :: seconds
+
+  ! local parameters
+  integer(kind=8) :: clock_end
+
+  call system_clock(clock_end)
+
+  seconds = dble(clock_end - clock_start)/dble(clock_rate)
+
+  end subroutine toc
+
+  end program gf3d_events_demo

--- a/EXAMPLES/green_function_database/global/api_demos/python/.gitignore
+++ b/EXAMPLES/green_function_database/global/api_demos/python/.gitignore
@@ -1,0 +1,5 @@
+# the demonstrations' own output
+gf3d_api_demo.png
+gf3d_events_demo.png
+__pycache__/
+*.png

--- a/EXAMPLES/green_function_database/global/api_demos/python/gf3d_api_demo.py
+++ b/EXAMPLES/green_function_database/global/api_demos/python/gf3d_api_demo.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python
+"""A runnable tour of the gf3d Python API, on the global example database.
+
+Four things, in order, each printing what it measured:
+
+  1. open the database and say what is in it
+  2. extract seismograms and their ten partial derivatives, in memory
+  3. check the identity the moment-tensor partials satisfy exactly
+  4. use a centroid partial as a derivative -- predict the seismogram of a
+     relocated source, and show the prediction improves quadratically as the
+     relocation shrinks
+
+Step 4 is the one worth reading. Everything before it can be had from
+`xgf3d` and a pile of SAC files; what the in-memory API is for is the
+inversion loop, where the partials are Frechet derivatives to be used, not
+traces to be written. A first-order Taylor step is the smallest honest
+demonstration that they are derivatives at all: get the sign, the units or
+the scaling wrong and the prediction does not converge, whatever the traces
+look like.
+
+The script writes one figure and changes nothing else. It is not part of
+the Snakemake workflow -- nothing in the Snakefile refers to this directory
+-- so run it by hand, after the workflow has built `../../GFDB`.
+
+Usage
+-----
+  cd EXAMPLES/green_function_database/global/api_demos/python
+  ../../../.venv/bin/python gf3d_api_demo.py [--station NET.STA] [--component N|E|Z]
+                                          [--step DEGREES] [--png FILE] [--no-plot]
+
+`--station` and `--component` choose what the figure draws; the numbers are
+computed for every station either way. `--step` is the relocation used in
+step 4, in degrees of latitude.
+
+Requires numpy, matplotlib (for the figure), and a built `lib/libgf3d.so`
+-- see `utils/green_function/gf3d/README.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# The package normally comes from an install (`pip install -e
+# utils/green_function`) or from PYTHONPATH. The example's own virtual
+# environment has neither, so that a reader who has only run `uv sync` can
+# still execute this file, fall back to the tree this script lives in.
+try:
+    import gf3d
+except ImportError:
+    # .../EXAMPLES/green_function_database/global/api_demos/python/this.py
+    _repo = Path(__file__).resolve().parents[5]
+    sys.path.insert(0, str(_repo / "utils" / "green_function"))
+    try:
+        import gf3d
+    except ImportError:
+        raise SystemExit(
+            f"cannot import gf3d, and it is not at {_repo / 'utils' / 'green_function'}\n"
+            "either run this script from inside a specfem3d_globe tree, or\n"
+            "  pip install -e <repo>/utils/green_function"
+        ) from None
+
+
+HERE = Path(__file__).resolve().parent
+EXAMPLE = HERE.parents[1]          # .../green_function_database/global
+DEFAULT_DB = EXAMPLE / "GFDB"
+DEFAULT_CMT = EXAMPLE / "validation_data" / "CMTSOLUTION"
+
+TIMINGS = []
+
+
+def rule(title):
+    print()
+    print(title)
+    print("-" * len(title))
+
+
+def timed(label, fn, *args, **kwargs):
+    """Call fn, record how long it took, and report it."""
+    t0 = time.perf_counter()
+    result = fn(*args, **kwargs)
+    ms = (time.perf_counter() - t0) * 1e3
+    TIMINGS.append((label, ms))
+    return result, ms
+
+
+def _mpl():
+    """matplotlib, headless. Imported here rather than at the top so that
+    --no-plot needs no display and no matplotlib at all."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    return plt
+
+
+# ---------------------------------------------------------------------------
+# 1-3: open, extract, and the identity
+# ---------------------------------------------------------------------------
+
+
+def describe(db):
+    rule("1. the database")
+    info = db.info
+    print(f"  path              {db.path}")
+    print(f"  elements          {info['nelem']}")
+    print(f"  stored samples    {info['nt_subsampled']} of {info['nstep']} solver steps")
+    print(f"  sample spacing    {info['dt']} s x {info['subsample_step']} "
+          f"= {info['dt'] * info['subsample_step']:.4g} s")
+    print(f"  topography        {info['topography']}   ellipticity {info['ellipticity']}")
+    print(f"  stations          {info['nstations']}")
+    for s in db.stations:
+        print(f"    {s.id:<10s} {s.latitude:9.4f} {s.longitude:10.4f}   "
+              f"burial {s.depth_m:6.1f} m")
+
+
+def extract(db, cmt):
+    rule("2. seismograms and partial derivatives")
+
+    # locating is separated out only to time it: db.partials() would do it
+    # anyway. The first locate in a process is the expensive one -- it builds
+    # the element search tree, and loads the topography grid -- and every
+    # later one reuses both.
+    loc, t_locate = timed("db.locate(...)  first call", db.locate,
+                          cmt.latitude, cmt.longitude, cmt.depth)
+    _, t_locate2 = timed("db.locate(...)  again", db.locate,
+                         cmt.latitude, cmt.longitude, cmt.depth)
+    r, t_part = timed("db.partials(cmt)", db.partials, cmt)
+
+    print(f"  db.locate         {t_locate:7.1f} ms   (first call: builds the search tree)")
+    print(f"                    {t_locate2:7.1f} ms   (second call: the tree is already there)")
+    print(f"  db.partials       {t_part:7.1f} ms   element {loc.ielem}, "
+          f"{loc.morton_hex}")
+    print()
+    print(f"  seismograms       {r.data.shape}   (stations, components N/E/Z, samples)")
+    print(f"  partials          {r.dp.shape}   (stations, parameters, components, samples)")
+    print(f"  time axis         {r.t.shape}, {r.t[0]:.2f} s to {r.t[-1]:.2f} s "
+          f"relative to the centroid time")
+    print(f"  peak displacement {np.abs(r.data).max():.4e} m")
+    print()
+    print("  parameter  unit")
+    for name, unit in zip(r.dp_names, r.dp_units):
+        print(f"    {name:<8s} {unit}")
+
+    if cmt.centroid_time is not None:
+        print()
+        print(f"  note: t = 0 is the centroid time, {cmt.centroid_time.isoformat()},")
+        print(f"        which is the origin time plus the file's {cmt.time_shift:g} s shift.")
+        print("        The shift is header metadata; it is not in the trace.")
+
+    return r
+
+
+def identity(r, cmt):
+    rule("3. the moment-tensor partials are exact")
+
+    m = np.asarray(cmt.tensor)
+    reconstructed = (r.dp[:, :6] * m[None, :, None, None]).sum(axis=1)
+    err = np.abs(reconstructed - r.data).max() / np.abs(r.data).max()
+
+    print("  The first six partials are per dyne-cm and the seismogram is linear")
+    print("  in the moment tensor, so contracting them with the CMTSOLUTION's own")
+    print("  components has to give the seismogram back:")
+    print()
+    print("    (dp[:, :6] * cmt.tensor).sum(1)  vs  data")
+    print(f"    max difference {err:.3e} of the trace peak")
+    print()
+    print("  So a moment-tensor perturbation needs no re-extraction at all: the")
+    print("  six partials *are* the forward operator. That is what makes a linear")
+    print("  moment-tensor inversion one matrix solve over these arrays.")
+
+    return err
+
+
+# ---------------------------------------------------------------------------
+# 4: the centroid partials are derivatives
+# ---------------------------------------------------------------------------
+
+
+def frechet(db, cmt, r, step, nhalve=2):
+    """Predict a relocated seismogram from dp/dlat, and halve the step."""
+    rule("4. the centroid partials are derivatives")
+
+    print("  Relocating the source changes the seismogram non-linearly, so here")
+    print("  the partial is a genuine derivative and one Taylor term is only an")
+    print("  approximation:")
+    print()
+    print("    u(lat + h)  ~=  u(lat) + h * du/dlat")
+    print()
+    print("  The error of that must fall as h^2. Halving h therefore divides it")
+    print("  by four -- and a partial with the wrong sign, units or scaling")
+    print("  cannot produce that, however plausible its traces look.")
+    print()
+
+    ilat = r.dp_names.index("lat")
+    peak = np.abs(r.data).max()
+
+    steps, errors, truths, predictions = [], [], [], []
+    for k in range(nhalve + 1):
+        h = step / (2 ** k)
+
+        moved = copy.deepcopy(cmt)
+        moved.latitude = cmt.latitude + h
+
+        try:
+            truth, _ = timed(f"db.seismograms(...)  relocated {h:g} deg",
+                             lambda s: db.seismograms(s).data, moved)
+        except gf3d.GF3DError as exc:
+            print(f"    step {h:<9g} could not be extracted: {exc.name}")
+            print("    (the relocated source left the database; try a smaller --step)")
+            break
+
+        predicted = r.data + r.dp[:, ilat] * h
+        err = np.abs(predicted - truth).max() / peak
+
+        steps.append(h)
+        errors.append(err)
+        truths.append(truth)
+        predictions.append(predicted)
+
+    if not steps:
+        print("  nothing to report: no relocation could be extracted.")
+        return steps, errors, truths, predictions
+
+    print(f"    {'step [deg]':<12s} {'error / peak':<14s} {'ratio':<8s}")
+    for k, (h, err) in enumerate(zip(steps, errors)):
+        ratio = f"{errors[k - 1] / err:.2f}" if k else ""
+        print(f"    {h:<12g} {err:<14.3e} {ratio:<8s}")
+
+    if len(errors) > 1:
+        ratios = [errors[k - 1] / errors[k] for k in range(1, len(errors))]
+        mean = sum(ratios) / len(ratios)
+        verdict = "second order, as a first derivative must be" if 3.0 < mean < 5.0 \
+            else "NOT second order -- something is wrong"
+        print()
+        print(f"  mean ratio {mean:.2f}: {verdict}")
+
+    return steps, errors, truths, predictions
+
+
+# ---------------------------------------------------------------------------
+# the figure
+# ---------------------------------------------------------------------------
+
+
+def plot(r, cmt, ista, icomp, steps, errors, truths, predictions, png):
+    plt = _mpl()
+
+    sid = r.station_ids[ista]
+    comp = "NEZ"[icomp]
+    t = r.t
+
+    fig = plt.figure(figsize=(13, 10.5))
+    gs = fig.add_gridspec(nrows=4, ncols=1, height_ratios=[1.0, 1.7, 1.0, 0.85],
+                          hspace=0.38)
+
+    # -- the seismogram ----------------------------------------------------
+    ax = fig.add_subplot(gs[0])
+    for j, c in enumerate("NEZ"):
+        ax.plot(t, r.data[ista, j], lw=0.9, label=c)
+    ax.axvline(0.0, color="0.5", lw=0.5)
+    ax.set_xlim(t[0], t[-1])
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=8, ncol=3, loc="upper right")
+    ax.set_ylabel("displacement [m]", fontsize=8)
+    ax.tick_params(labelsize=7)
+    ax.set_title(f"{sid}   db.partials(cmt).data[{ista}]   "
+                 f"(t = 0 is the centroid time)", fontsize=10, loc="left")
+
+    # -- the ten Frechet kernels -------------------------------------------
+    # normalised individually: they span thirty orders of magnitude between
+    # m/dyne-cm and m/s, so only the shapes can share an axis
+    ax = fig.add_subplot(gs[1])
+    ndp = r.dp.shape[1]
+    peaks = []
+    for ip in range(ndp):
+        trace = r.dp[ista, ip, icomp]
+        scale = np.abs(trace).max()
+        peaks.append(scale)
+        ax.plot(t, 0.42 * trace / scale + ip, "k-", lw=0.7)
+    ax.axvline(0.0, color="0.5", lw=0.5)
+    ax.set_xlim(t[0], t[-1])
+    ax.set_ylim(-0.7, ndp - 0.3)
+    ax.set_yticks(range(ndp))
+    ax.set_yticklabels(
+        [f"{n}   {p:.1e} {u}" for n, p, u in zip(r.dp_names, peaks, r.dp_units)],
+        fontsize=6.5, fontfamily="monospace",
+    )
+    ax.grid(True, axis="x", alpha=0.3)
+    ax.tick_params(labelsize=7)
+    ax.set_title(f"the ten partial derivatives, {sid} {comp}, "
+                 "each normalised by the peak given with its name",
+                 fontsize=10, loc="left")
+
+    # -- the Frechet check, the overlay ------------------------------------
+    ax = fig.add_subplot(gs[2])
+    if steps:
+        h = steps[0]
+        ax.plot(t, truths[0][ista, icomp], "k-", lw=1.0,
+                label=f"re-extracted at latitude + {h:g}°")
+        ax.plot(t, predictions[0][ista, icomp], "r--", lw=1.0,
+                label="predicted from the unperturbed run, one Taylor term")
+    ax.axvline(0.0, color="0.5", lw=0.5)
+    ax.set_xlim(t[0], t[-1])
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=7, loc="upper right")
+    ax.set_ylabel("displacement [m]", fontsize=8)
+    ax.tick_params(labelsize=7)
+    ax.set_title("a relocated source, predicted rather than re-extracted",
+                 fontsize=10, loc="left")
+
+    # -- and the residuals, on an axis where they are visible ---------------
+    # the whole point of the panel: on the scale above, a 0.3 % residual is
+    # a line thickness
+    ax = fig.add_subplot(gs[3])
+    for k, hk in enumerate(steps):
+        resid = predictions[k][ista, icomp] - truths[k][ista, icomp]
+        ax.plot(t, resid, lw=0.8,
+                label=f"{hk:g}°   max {errors[k]:.2e} of the trace peak")
+    # The last khalf samples are where the source time function kernel runs
+    # off the end of the stored record and convolves zeros, so everything is
+    # a little wrong there -- for the same reason in every trace, which is
+    # why the ratios above are unaffected. The plan says how many.
+    if r.plan.khalf > 0:
+        edge = t[-1] - r.plan.khalf * r.plan.dt_sub
+        ax.axvspan(edge, t[-1], color="0.88", zorder=0)
+        ax.text(edge, ax.get_ylim()[0],
+                f" last {r.plan.khalf} samples: the kernel runs off the record",
+                fontsize=6.5, va="bottom", ha="left", color="0.35")
+    ax.axhline(0.0, color="0.6", lw=0.6, ls=":")
+    ax.axvline(0.0, color="0.5", lw=0.5)
+    ax.set_xlim(t[0], t[-1])
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=7, ncol=3, loc="lower left", title="relocation step",
+              title_fontsize=7)
+    ax.set_xlabel("time relative to the centroid time [s]", fontsize=8)
+    ax.set_ylabel("prediction − truth [m]", fontsize=8)
+    ax.tick_params(labelsize=7)
+    ax.set_title("the residual, which falls fourfold each time the step is halved",
+                 fontsize=10, loc="left")
+
+    fig.suptitle(
+        f"gf3d Python API — event {cmt.event_name or '(unnamed)'} at "
+        f"{cmt.latitude:.3f}°, {cmt.longitude:.3f}°, {cmt.depth:.1f} km",
+        fontsize=11,
+    )
+
+    fig.savefig(png, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"\nwrote {png}")
+
+
+# ---------------------------------------------------------------------------
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--db", default=str(DEFAULT_DB), help="the GFDB directory")
+    ap.add_argument("--cmt", default=str(DEFAULT_CMT), help="a CMTSOLUTION")
+    ap.add_argument("--station", default=None, help="NET.STA to draw (default: the first)")
+    ap.add_argument("--component", default="Z", choices=list("NEZ"),
+                    help="component to draw (default: Z)")
+    ap.add_argument("--step", type=float, default=0.05,
+                    help="relocation for step 4, in degrees of latitude (default: 0.05)")
+    ap.add_argument("--png", default=str(HERE / "gf3d_api_demo.png"), help="figure to write")
+    ap.add_argument("--no-plot", action="store_true", help="numbers only")
+    args = ap.parse_args(argv)
+
+    db_path = Path(args.db)
+    if not (db_path / "mesh_info.h5").exists():
+        raise SystemExit(
+            f"no database at {db_path}\n"
+            "The example's database is built by the workflow, and is gitignored:\n"
+            f"    cd {EXAMPLE}\n"
+            "    snakemake -j1\n"
+            "Or point --db at another GFDB directory."
+        )
+
+    cmt_path = Path(args.cmt)
+    if not cmt_path.exists():
+        raise SystemExit(f"no CMTSOLUTION at {cmt_path}")
+
+    print("gf3d Python API demonstration")
+    print(f"  package  {gf3d.__version__}   library {gf3d.library_version()}")
+    print(f"  from     {gf3d.library_path}")
+
+    cmt = gf3d.CMTSource.read(cmt_path)
+
+    db, t_open = timed("gf3d.Database(path)", gf3d.Database, db_path)
+    with db:
+        print(f"\n  opening the database took {t_open:.1f} ms "
+              "(metadata only; elements are read on demand)")
+        describe(db)
+        r = extract(db, cmt)
+        identity(r, cmt)
+        steps, errors, truths, predictions = frechet(db, cmt, r, args.step)
+        if not steps:
+            raise SystemExit(
+                f"\nthe relocation of {args.step}° left the database, so step 4 showed "
+                "nothing.\nTry a smaller --step (the default, 0.05, works on the shipped "
+                "example)."
+            )
+
+        if not args.no_plot:
+            if args.station and args.station not in r.station_ids:
+                raise SystemExit(
+                    f"\nno station {args.station!r} in this database.\n"
+                    f"It has: {', '.join(r.station_ids)}"
+                )
+            ista = r.station_ids.index(args.station) if args.station else 0
+            icomp = "NEZ".index(args.component)
+            plot(r, cmt, ista, icomp, steps, errors, truths, predictions, args.png)
+
+    report_timings(db.info["nstations"], r.plan.nt)
+
+    return 0
+
+
+def report_timings(nsta, nt):
+    rule("timings")
+
+    width = max(len(label) for label, _ in TIMINGS)
+    for label, ms in TIMINGS:
+        print(f"  {label:<{width}s}  {ms:8.1f} ms")
+
+    total = sum(ms for _, ms in TIMINGS)
+    print(f"  {'':<{width}s}  {'-' * 8}")
+    print(f"  {'in the library':<{width}s}  {total:8.1f} ms")
+    print()
+    print(f"  Every extraction above produced {nsta} stations x 3 components x {nt}")
+    print("  samples. The database is opened once and stays open; the first locate")
+    print("  pays for the element search tree and the topography grid, and every")
+    print("  source after it reuses them. That difference -- an open per event")
+    print("  against an open per run -- is the whole argument for the in-memory")
+    print("  API over a subprocess and a SAC file per iteration.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/EXAMPLES/green_function_database/global/api_demos/python/gf3d_events_demo.py
+++ b/EXAMPLES/green_function_database/global/api_demos/python/gf3d_events_demo.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""Seismograms for several events from one open database.
+
+The global example's database was not built for a single earthquake. Its
+`db_base/DATA/GF_LOCATIONS` names three hypocentres --
+
+    -35.909  -72.733   35.0 km    2010 Chile earthquake (Maule)
+     -5.812  -75.270  122.6 km    2019 Peru earthquake
+    -13.0    -67.0     10.0 km    near the centre of the chunk
+
+-- and the reciprocal runs stored the strain around all of them. That is
+what a Green function database is for: the expensive simulations are done
+per *station*, once, and any source inside the covered volume is then a
+cheap look-up.
+
+This script is that use case. It opens the database once and extracts
+seismograms for every hypocentre the database declares, timing each one, so
+the shape of the cost is visible: a few milliseconds to open, a first
+locate that pays for the element search tree and the topography grid, and
+then one extraction per event that reads only the elements it needs.
+
+The moment tensor is held fixed at the validation event's, so the three
+records differ only by where the source sits. A real catalogue would vary
+the mechanism too, and that costs nothing extra: the moment-tensor partials
+are exact, so a new mechanism at the same hypocentre is a contraction of
+arrays already in memory rather than another extraction. `gf3d_api_demo.py`
+shows that identity.
+
+Usage
+-----
+  cd EXAMPLES/green_function_database/global/api_demos/python
+  ../../../.venv/bin/python gf3d_events_demo.py [--component N|E|Z] [--png FILE]
+                                             [--no-plot]
+
+Requires numpy, matplotlib (for the figure), and a built `lib/libgf3d.so`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# See the note in gf3d_api_demo.py: the example's virtual environment does
+# not have the package, so fall back to the tree this script lives in.
+try:
+    import gf3d
+except ImportError:
+    # .../EXAMPLES/green_function_database/global/api_demos/python/this.py
+    _repo = Path(__file__).resolve().parents[5]
+    sys.path.insert(0, str(_repo / "utils" / "green_function"))
+    try:
+        import gf3d
+    except ImportError:
+        raise SystemExit(
+            f"cannot import gf3d, and it is not at {_repo / 'utils' / 'green_function'}\n"
+            "either run this script from inside a specfem3d_globe tree, or\n"
+            "  pip install -e <repo>/utils/green_function"
+        ) from None
+
+
+HERE = Path(__file__).resolve().parent
+EXAMPLE = HERE.parents[1]          # .../green_function_database/global
+DEFAULT_DB = EXAMPLE / "GFDB"
+DEFAULT_CMT = EXAMPLE / "validation_data" / "CMTSOLUTION"
+DEFAULT_LOCATIONS = EXAMPLE / "db_base" / "DATA" / "GF_LOCATIONS"
+
+
+def read_locations(path):
+    """The hypocentres a GF_LOCATIONS file declares, with their labels.
+
+    Three columns, latitude longitude depth_km, with `#` comments. The
+    comment immediately above a row is taken as that row's name, which is
+    how the shipped file labels its events.
+    """
+    events = []
+    label = ""
+    for line in Path(path).read_text().splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            label = stripped.lstrip("#").strip()
+            continue
+        fields = stripped.split()
+        if len(fields) < 3:
+            continue
+        events.append((label or f"event {len(events) + 1}",
+                       float(fields[0]), float(fields[1]), float(fields[2])))
+        label = ""
+    return events
+
+
+def _mpl():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    return plt
+
+
+def plot(results, station_ids, comp, png, cmt):
+    plt = _mpl()
+
+    icomp = "NEZ".index(comp)
+    nsta = len(station_ids)
+
+    fig, axes = plt.subplots(nsta, 1, figsize=(13, 2.1 * nsta + 1.2), sharex=True)
+    if nsta == 1:
+        axes = [axes]
+
+    colours = ["tab:blue", "tab:orange", "tab:green", "tab:red", "tab:purple"]
+
+    for ista, (ax, sid) in enumerate(zip(axes, station_ids)):
+        for k, res in enumerate(results):
+            r = res["result"]
+            ax.plot(r.t, r.data[ista, icomp], lw=0.9, color=colours[k % len(colours)],
+                    label=(f"{res['label']}   {res['lat']:.3f}°, {res['lon']:.3f}°, "
+                           f"{res['depth']:.1f} km" if ista == 0 else None))
+        ax.axvline(0.0, color="0.5", lw=0.5)
+        ax.grid(True, alpha=0.3)
+        ax.set_ylabel(f"{sid}\n{comp} [m]", fontsize=8)
+        ax.tick_params(labelsize=7)
+        if ista == 0:
+            ax.legend(fontsize=7, loc="upper right")
+
+    axes[-1].set_xlabel("time relative to the centroid time [s]", fontsize=8)
+    axes[0].set_xlim(results[0]["result"].t[0], results[0]["result"].t[-1])
+
+    fig.suptitle(
+        f"one open database, {len(results)} hypocentres — same moment tensor "
+        f"(M0 from {cmt.event_name or 'the validation event'}), same stations",
+        fontsize=11,
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    fig.savefig(png, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"\nwrote {png}")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--db", default=str(DEFAULT_DB), help="the GFDB directory")
+    ap.add_argument("--cmt", default=str(DEFAULT_CMT),
+                    help="a CMTSOLUTION, for the moment tensor and origin time")
+    ap.add_argument("--locations", default=str(DEFAULT_LOCATIONS),
+                    help="a GF_LOCATIONS file listing the hypocentres")
+    ap.add_argument("--component", default="Z", choices=list("NEZ"),
+                    help="component to draw (default: Z)")
+    ap.add_argument("--png", default=str(HERE / "gf3d_events_demo.png"),
+                    help="figure to write")
+    ap.add_argument("--no-plot", action="store_true", help="numbers only")
+    args = ap.parse_args(argv)
+
+    db_path = Path(args.db)
+    if not (db_path / "mesh_info.h5").exists():
+        raise SystemExit(
+            f"no database at {db_path}\n"
+            "The example's database is built by the workflow, and is gitignored:\n"
+            f"    cd {EXAMPLE}\n"
+            "    snakemake -j1"
+        )
+    if not Path(args.locations).exists():
+        raise SystemExit(f"no GF_LOCATIONS file at {args.locations}")
+
+    events = read_locations(args.locations)
+    if not events:
+        raise SystemExit(f"{args.locations} declares no hypocentres")
+
+    cmt = gf3d.CMTSource.read(args.cmt)
+
+    print("gf3d: several events, one open database")
+    print(f"  library  {gf3d.library_version()} from {gf3d.library_path}")
+    print(f"  events   {len(events)}, from {args.locations}")
+    print(f"  mechanism held fixed at {cmt.event_name or 'the validation event'}'s, "
+          "so only the hypocentre differs")
+
+    t0 = time.perf_counter()
+    db = gf3d.Database(db_path)
+    t_open = (time.perf_counter() - t0) * 1e3
+
+    with db:
+        station_ids = db.station_ids
+        print(f"  stations {', '.join(station_ids)}")
+        print()
+        print(f"  gf3d.Database(...)            {t_open:7.1f} ms")
+        print()
+
+        header = (f"  {'event':<28s} {'lat':>9s} {'lon':>10s} {'depth':>7s} "
+                  f"{'elem':>5s} {'locate':>9s} {'extract':>9s} {'peak [m]':>11s}")
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+
+        results = []
+        for label, lat, lon, depth in events:
+            src = copy.deepcopy(cmt)
+            src.latitude, src.longitude, src.depth = lat, lon, depth
+
+            try:
+                t0 = time.perf_counter()
+                loc = db.locate(lat, lon, depth)
+                t_loc = (time.perf_counter() - t0) * 1e3
+
+                t0 = time.perf_counter()
+                r = db.seismograms(src)
+                t_ext = (time.perf_counter() - t0) * 1e3
+            except gf3d.GF3DError as exc:
+                print(f"  {label:<28s} {lat:9.3f} {lon:10.3f} {depth:7.1f} "
+                      f"   --  {exc.name}")
+                continue
+
+            print(f"  {label:<28s} {lat:9.3f} {lon:10.3f} {depth:7.1f} "
+                  f"{loc.ielem:5d} {t_loc:7.1f} ms {t_ext:7.1f} ms "
+                  f"{np.abs(r.data).max():11.4e}")
+
+            results.append({"label": label, "lat": lat, "lon": lon, "depth": depth,
+                            "result": r, "locate_ms": t_loc, "extract_ms": t_ext})
+
+        if not results:
+            raise SystemExit("\nnone of the declared hypocentres is inside this database")
+
+        # per station, so the reader can see which event each station favours
+        print()
+        print("  peak amplitude per station [m]")
+        width = max(len(r["label"]) for r in results)
+        print(f"    {'event':<{width}s}  " +
+              "  ".join(f"{s:>11s}" for s in station_ids))
+        for res in results:
+            peaks = np.abs(res["result"].data).max(axis=(1, 2))
+            print(f"    {res['label']:<{width}s}  " +
+                  "  ".join(f"{p:11.4e}" for p in peaks))
+
+        extracts = [r["extract_ms"] for r in results]
+        print()
+        print(f"  {len(results)} events: {t_open:.1f} ms to open, "
+              f"{results[0]['locate_ms']:.1f} ms for the first locate, then "
+              f"{np.mean(extracts):.1f} ms per event on average.")
+        print("  The reciprocal simulations that built this database took about")
+        print("  forty minutes. Every source inside it is now a look-up.")
+
+        if not args.no_plot:
+            plot(results, station_ids, args.component, args.png, cmt)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Makefile.in
+++ b/Makefile.in
@@ -41,6 +41,16 @@ FCFLAGS_f90 = -I${SETUP} @FCFLAGS_f90@ -I@top_builddir@
 FC_MODEXT = @FC_MODEXT@
 FC_MODDIR = @FC_MODDIR@
 
+# module output/search flags, used by src/gf3d/ to build the -fPIC objects of
+# lib/libgf3d.so into their own module directory.
+#
+# configure appends ${ac_empty} to either flag when it needs a trailing space
+# (ifort's "-module ", as opposed to gfortran's "-J"), so ac_empty must exist
+# here and expand to nothing: see AC_FC_MODULE_OUTPUT_FLAG in m4/cit_backports.m4.
+ac_empty =
+FC_MODOUT = @FC_MODOUT@
+FC_MODINC = @FC_MODINC@
+
 FCCOMPILE_CHECK =@FCENV@ ${FC} ${FCFLAGS} $(FLAGS_CHECK)
 
 MPIFCCOMPILE_CHECK =@FCENV@ ${MPIFC} ${FCFLAGS} $(FLAGS_CHECK)
@@ -759,6 +769,7 @@ ifeq ($(HDF5), yes)
 	@echo "for Green function database extraction: [make gf3d]"
 	@echo "    xgf3d"
 	@echo "    lib/libgf3d.a"
+	@echo "    lib/libgf3d.so   (with include/gf3d.h for C and include/gf3d.mod for Fortran)"
 	@echo ""
 endif
 

--- a/src/gf3d/gf3d.F90
+++ b/src/gf3d/gf3d.F90
@@ -1,0 +1,243 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- The public face of libgf3d.
+!----
+!---- One module, so that a program outside this tree needs
+!----
+!----     use gf3d
+!----
+!---- and nothing else. Everything below is re-exported from the gf_*
+!---- modules that implement it; the only code here is gf_release() and
+!---- get_seismograms(), both of which exist to spare a caller a sequence it
+!---- would otherwise have to get right itself.
+!----
+!---- Build and link
+!---- --------------
+!----     make gf3d
+!---- installs include/gf3d.mod beside include/gf3d.h, so
+!----
+!----     <FC> myprog.f90 -I<repo>/include -L<repo>/lib -lgf3d <HDF5 link line>
+!----
+!---- links against the static library. lib/libgf3d.so is the same library as
+!---- a shared object, for ctypes and for anything that dlopen()s it.
+!----
+!---- Relation to GF3DF
+!---- -----------------
+!---- The name `gf3d` is GF3DF's, deliberately: a downstream GCMT-style
+!---- caller writes `use gf3d` there too. The type aliases t_GF and t_source
+!---- and the generic get_seismograms() below carry that as far as it goes
+!---- honestly. It does not go all the way, and the differences are not
+!---- cosmetic:
+!----
+!----   * t_source there carries Mrr..Mtp in dyne-cm and a `time_shift`;
+!----     t_gf_source here carries a non-dimensional moment_tensor(6) and
+!----     min_tshift_src_original, because get_cmt() has already divided by
+!----     scaleM. Multiply by src%scale_moment to get dyne-cm back.
+!----   * read_GF(file) + GF%get_kdtree() becomes gf_open(dir,db,ierr): the
+!----     database is a directory tree, not one file, and the kd-tree is
+!----     built on the first locate.
+!----   * every routine returns ierr instead of stopping.
+!----
+!---- So the port of a downstream caller is the open call, the source fields
+!---- and an error argument -- not a drop-in.
+!----
+!---- Errors
+!---- ------
+!---- No routine reachable from here stops. Each returns one of the GF_*
+!---- codes; gf_error_string(code) is a short name and gf_errmsg the message
+!---- from the last failure.
+!----
+
+  module gf3d
+
+  !--- types, constants and error handling
+  use gf_par, only: &
+    t_gfdb, t_gf_station, t_gf_source, t_gf_location, t_gf_taxis, t_gf_stf, &
+    GF3D_VERSION, GF_NCOMP, GF_MORTON_HEXLEN, GF_STATION_ID_LEN, &
+    GF_XI_TOL, GF_NCAND, GF_ANCHOR_TOL, &
+    GF_OK, GF_ERR_NO_HDF5, GF_ERR_NO_PATH, GF_ERR_NO_FILE, GF_ERR_HDF5, &
+    GF_ERR_IO, GF_ERR_FORMAT, GF_ERR_MISMATCH, GF_ERR_INCOMPLETE, &
+    GF_ERR_ALLOC, GF_ERR_ARG, GF_ERR_NO_ELEMENT, GF_ERR_GEOMETRY, &
+    GF_SRC_FORCE, GF_SRC_CMT, &
+    GF_STF_NONE, GF_STF_GAUSS, GF_STF_HEAVI, GF_STF_TRUNC, &
+    gf_set_error, gf_error_string, gf_errmsg, gf_is_finite
+
+  !--- GF3DF-compatible aliases, so that `use gf3d, only: t_GF, t_source`
+  !--- keeps naming something
+  use gf_par, only: t_GF => t_gfdb, t_source => t_gf_source
+
+  !--- opening and interrogating a database
+  use gf_database, only: &
+    gf_open, gf_close, gf_load_topo, gf_check_completion, gf_print_info, &
+    gf_topo_elevation, gf_topo_gradient
+
+  !--- sources
+  use gf_source, only: &
+    gf_read_source, gf_read_cmt_source, gf_read_force_source, &
+    gf_source_set_cmt, gf_source_set_force, &
+    gf_detect_source_type, gf_force_direction, gf_print_source
+
+  !--- locating a source in the mesh
+  use gf_locate, only: &
+    gf_locate_source, gf_locate_release, gf_check_anchors, gf_check_anchors_all
+
+  !--- the source time function and the output time axis
+  use gf_stf, only: &
+    gf_stf_plan, gf_taxis_plan, gf_taxis_times, gf_stf_kind_name, gf_print_stf, &
+    gf_hdur_gaussian
+
+  !--- extraction
+  use gf_seismograms, only: &
+    gf_time_axis, gf_seis_plan, gf_seis, gf_seis_cmt, gf_seis_force, &
+    gf_seis_cmt_partials, gf_write_seis, gf_write_partials, gf_write_dump
+
+  !--- partial derivatives: the count, the slot order, the names and units
+  use gf_partials, only: &
+    gf_partials_ndp, GF_NDP_MT, GF_NDP_LOC, &
+    GF_DP_MRR, GF_DP_MTT, GF_DP_MPP, GF_DP_MRT, GF_DP_MRP, GF_DP_MTP, &
+    GF_DP_LAT, GF_DP_LON, GF_DP_DEP, GF_DP_TIM, &
+    GF_DP_NAME, GF_DP_UNIT
+
+  !--- SAC output. Only the whole-database writer: the header record and the
+  !--- single-trace writer are for xgf3d and for the tests, and exporting
+  !--- them would mean exporting t_gf_sac_header with them.
+  use gf_sac, only: gf_write_sac, GF_SAC_CHANNEL
+
+  implicit none
+
+  public
+
+  contains
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine gf_release(db)
+
+! closes a database and frees the process-wide search tree
+!
+! gf_close() alone is not enough. The kd-tree lives in module variables of
+! src/shared/search_kdtree.f90, which gf_locate owns on the database's
+! behalf; gf_close() cannot release it, because gf_locate depends on
+! gf_database and the reverse call would be circular. So a caller that opens
+! and closes databases over a long-lived process -- an inversion loop, a
+! Python interpreter -- must call both, in this order, and this routine is
+! that pair.
+
+  implicit none
+
+  type(t_gfdb), intent(inout) :: db
+
+  call gf_locate_release()
+  call gf_close(db)
+
+  end subroutine gf_release
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine get_seismograms(db,src,synt,dp,itypsokern,t,ierr)
+
+! seismograms, and optionally their partial derivatives, for one source
+!
+! The whole of xgf3d's --seis path in one call: locate, plan, extract. The
+! name and the (synt, dp, itypsokern) shape are GF3DF's get_sdp(), so that a
+! downstream caller reads familiarly -- but the arrays are ours:
+!
+!   synt(nsta, 3, nt)          metres, components N/E/Z
+!   dp(ndp, nsta, 3, nt)       ndp = 0, 6 or 10 for itypsokern = 0, 1, 2
+!   t(nt)                      seconds relative to the centroid time
+!
+! and both are allocated here. itypsokern = 3 (GF3DF's half-duration
+! partial) is not supported; see gf_partials.
+!
+! The output axis is specfem's own for the forward run, 1.5*hdur before the
+! centroid time for a CMT source. A caller that wants another start time
+! calls gf_seis_plan/gf_seis directly, as xgf3d --t0 does.
+!
+! `src` is intent(in): unlike GF3DF, nothing is written back into it.
+
+  implicit none
+
+  type(t_gfdb), intent(inout) :: db          ! inout: the topography grid loads lazily
+  type(t_gf_source), intent(in) :: src
+  double precision, dimension(:,:,:), allocatable, intent(out) :: synt
+  double precision, dimension(:,:,:,:), allocatable, intent(out) :: dp
+  integer, intent(in) :: itypsokern
+  double precision, dimension(:), allocatable, intent(out) :: t
+  integer, intent(out) :: ierr
+
+  ! local parameters
+  type(t_gf_location) :: loc
+  type(t_gf_taxis) :: tax
+  type(t_gf_stf) :: stf
+  double precision, dimension(:), allocatable :: onset
+  integer :: ndp,ier
+
+  if (.not. db%is_open) then
+    call gf_set_error(ierr,GF_ERR_ARG,'get_seismograms: database is not open')
+    return
+  endif
+
+  call gf_partials_ndp(itypsokern,ndp,ierr)
+  if (ierr /= GF_OK) return
+
+  if (itypsokern > 0 .and. src%source_type /= GF_SRC_CMT) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'get_seismograms: partial derivatives are defined for a moment-tensor source only')
+    return
+  endif
+
+  call gf_locate_source(db,src%latitude,src%longitude,src%depth,loc,ierr)
+  if (ierr /= GF_OK) return
+
+  call gf_seis_plan(db,src,-1.d0,tax,stf,ierr)
+  if (ierr /= GF_OK) return
+
+  allocate(synt(db%nstations,GF_NCOMP,tax%nt), &
+           dp(max(ndp,0),db%nstations,GF_NCOMP,tax%nt), &
+           t(tax%nt),onset(db%nstations),stat=ier)
+  if (ier /= 0) then
+    call gf_set_error(ierr,GF_ERR_ALLOC,'get_seismograms: could not allocate the output arrays')
+    return
+  endif
+
+  if (itypsokern > 0) then
+    call gf_seis_cmt_partials(db,src,loc,tax,stf,itypsokern,ndp,synt,dp,t,onset,ierr)
+  else
+    call gf_seis(db,src,loc,tax,stf,synt,t,onset,ierr)
+  endif
+
+  deallocate(onset)
+
+  end subroutine get_seismograms
+
+  end module gf3d

--- a/src/gf3d/gf3d.h
+++ b/src/gf3d/gf3d.h
@@ -1,0 +1,374 @@
+/*
+ *=====================================================================
+ *
+ *                       S p e c f e m 3 D  G l o b e
+ *                       ----------------------------
+ *
+ *     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+ *                        Princeton University, USA
+ *                and CNRS / University of Marseille, France
+ *                 (there are currently many more authors!)
+ * (c) Princeton University and CNRS / University of Marseille, April 2014
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *=====================================================================
+ */
+
+/*
+ * libgf3d -- Green function extraction from a specfem3d_globe reciprocal
+ * database, as a C-callable library.
+ *
+ * The Fortran behind every function here is the same code bin/xgf3d runs;
+ * this is a facade over it (src/gf3d/gf3d_capi.F90), not a second
+ * implementation. The Python package in utils/green_function/gf3d/ is a
+ * ctypes wrapper over exactly these calls.
+ *
+ * Linking
+ * -------
+ *     cc myprog.c -I<repo>/include -L<repo>/lib -lgf3d <HDF5 link line>
+ *
+ * or dlopen()/ctypes.CDLL() on <repo>/lib/libgf3d.so, which has the HDF5
+ * library directories baked in as an rpath. Link C code with the Fortran
+ * driver (or add -lgfortran / -lifcore) so that the Fortran runtime comes
+ * along.
+ *
+ * Conventions
+ * -----------
+ * Return value    every function returns a GF_* code; GF_OK (0) is success.
+ *                 Nothing here can abort, exit or stop the calling process:
+ *                 that is the point of the facade, since a Fortran stop
+ *                 inside a shared object would kill a Python interpreter
+ *                 with no traceback.
+ * Handles         gf3d_open() returns a small positive integer, not a
+ *                 pointer. A stale or forged handle is rejected with
+ *                 GF_ERR_ARG rather than dereferenced.
+ * Output arrays   the caller allocates every one of them, sized from
+ *                 gf3d_get_plan() and gf3d_get_info(). Nothing is
+ *                 allocated on the library side and handed back.
+ * Array order     C order, i.e. the last index varies fastest:
+ *                     seis[ista][icomp][it]
+ *                     dp[ista][ip][icomp][it]
+ *                 with icomp 0,1,2 = N,E,Z.
+ * Indices         0-based (ista, icomp, ip), as C expects. The Fortran
+ *                 underneath is 1-based; the facade converts.
+ * Units           displacement in metres, time in seconds, latitude and
+ *                 longitude in degrees, depth in km (source) or metres
+ *                 (station burial), moment tensor in dyne-cm.
+ * Time origin     t = 0 is the *centroid* time, i.e. the source file's
+ *                 origin time plus its time shift. The time shift is
+ *                 carried in gf3d_source.time_shift as metadata and is not
+ *                 in the trace. (This is get_cmt()'s convention, and
+ *                 getting it backwards puts a trace 29 s out against real
+ *                 data for the shipped example.)
+ * Threads         not thread-safe. The library keeps process-wide state:
+ *                 the last error message, the kd-tree that serves whichever
+ *                 database located last, and specfem's shared_parameters.
+ *                 Serialise calls, as the Python wrapper does.
+ * Two databases   supported: each handle owns its own metadata. But the
+ *                 search tree is rebuilt whenever a locate switches
+ *                 database, so alternating between two of them is slow, and
+ *                 two databases of *different planets or topography grids*
+ *                 must not be used alternately at all.
+ */
+
+#ifndef GF3D_H
+#define GF3D_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* bumped when anything below changes incompatibly */
+#define GF3D_API_VERSION 1
+
+/* fits 'NET.STA': MAX_LENGTH_NETWORK_NAME + 1 + MAX_LENGTH_STATION_NAME */
+#define GF3D_STRLEN 64
+
+/* the number of databases that may be open at once */
+#define GF3D_MAX_HANDLES 32
+
+/* a Morton code as 16 hex digits, plus room for a terminator */
+#define GF3D_MORTON_STRLEN 24
+
+/* an open database. Valid values are 1..GF3D_MAX_HANDLES. */
+typedef int gf3d_handle;
+
+/* error codes; these are gf_par.F90's GF_* values, unchanged */
+enum gf3d_status {
+  GF_OK             = 0,
+  GF_ERR_NO_HDF5    = 1,   /* built without HDF5 */
+  GF_ERR_NO_PATH    = 2,   /* database directory not found */
+  GF_ERR_NO_FILE    = 3,
+  GF_ERR_HDF5       = 4,
+  GF_ERR_IO         = 5,
+  GF_ERR_FORMAT     = 6,   /* malformed database */
+  GF_ERR_MISMATCH   = 7,   /* incompatible database */
+  GF_ERR_INCOMPLETE = 8,   /* database missing element/station files */
+  GF_ERR_ALLOC      = 9,
+  GF_ERR_ARG        = 10,  /* invalid argument, including a bad handle */
+  GF_ERR_NO_ELEMENT = 11,  /* the point is not inside the database */
+  GF_ERR_GEOMETRY   = 12   /* degenerate element geometry */
+};
+
+/* source kinds */
+enum gf3d_source_type {
+  GF_SRC_FORCE = 1,
+  GF_SRC_CMT   = 2
+};
+
+/* fixed sizes */
+enum {
+  GF_NCOMP   = 3,   /* N, E, Z */
+  GF_NDP_MT  = 6,   /* itypsokern = 1: the six moment-tensor partials */
+  GF_NDP_LOC = 10   /* itypsokern = 2: those plus lat, lon, depth, time */
+};
+
+/*
+ * A seismic source, of either kind.
+ *
+ * For GF_SRC_CMT the fields used are latitude, longitude, depth_km, hdur,
+ * time_shift and moment; for GF_SRC_FORCE they are latitude, longitude,
+ * depth_km, hdur (= the FORCESOLUTION's f0), time_shift, force_stf,
+ * force_factor and force_dir. Set the rest to zero.
+ *
+ * hdur is the file's own field, unconverted: a CMTSOLUTION's *triangle*
+ * half duration (the Gaussian width specfem uses is hdur/1.628, applied
+ * inside), or a FORCESOLUTION's f0. The library applies specfem's own
+ * clamps, so a zero hdur becomes 5*dt exactly as get_cmt() would make it.
+ */
+typedef struct {
+  int    source_type;      /* GF_SRC_CMT or GF_SRC_FORCE */
+  int    force_stf;        /* force only: 0 Gaussian, 1 Ricker, 2 step,
+                              3 monochromatic, 4 Gaussian (Meschede) */
+  double latitude;         /* degrees */
+  double longitude;        /* degrees */
+  double depth_km;         /* km below the surface */
+  double hdur;             /* s (CMT: triangle half duration; force: f0) */
+  double time_shift;       /* s; metadata, not part of the trace */
+  double moment[6];        /* Mrr,Mtt,Mpp,Mrt,Mrp,Mtp in dyne-cm; CMT only */
+  double force_factor;     /* N; force only */
+  double force_dir[3];     /* E, N, Z-up; any length, force only */
+} gf3d_source;
+
+/* what a database says about itself */
+typedef struct {
+  int    nelem;            /* elements in the index */
+  int    nstations;
+  int    nstep;            /* solver time steps */
+  int    nt_subsampled;    /* stored samples = nstep / subsample_step */
+  int    subsample_step;
+  int    ngllx, nglly, ngllz;
+  int    topography;       /* 0 or 1 */
+  int    ellipticity;
+  int    rotation;
+  int    attenuation;
+  int    gravity;
+  int    pad_;             /* keeps the doubles 8-byte aligned explicitly */
+  double dt;               /* solver time step, s */
+  double t0;               /* first stored sample, s before the origin */
+  double r_planet;         /* m; the effective value, see below */
+  double rhoav;            /* kg/m^3; likewise */
+  double scale_displ;
+} gf3d_info;
+/*
+ * r_planet and rhoav are the values the library is *using*, which come from
+ * the database when it records them and from specfem's Earth defaults when
+ * it does not. The current writer stores neither RHOAV nor the flattening,
+ * so on the shipped example databases rhoav is the Earth default.
+ */
+
+typedef struct {
+  char   id[GF3D_STRLEN];        /* 'NET.STA' */
+  char   network[GF3D_STRLEN];
+  char   station[GF3D_STRLEN];
+  double latitude;               /* degrees */
+  double longitude;              /* degrees */
+  double depth_m;                /* burial, metres below the surface */
+  double hdur;                   /* Gaussian width of the reciprocal run, s */
+  double f_cutoff;               /* Hz */
+  double factor_force_source;    /* non-dimensional */
+  double time_shift;             /* s */
+} gf3d_station;
+
+/* where a source sits in the mesh */
+typedef struct {
+  int    ielem;                          /* 1..nelem, 0 if unset */
+  char   morton_hex[GF3D_MORTON_STRLEN];
+  double xi, eta, gamma;                 /* element coordinates */
+  double xyz[3];                         /* mapped position, non-dimensional */
+  double xyz_target[3];                  /* requested position */
+  double distance_km;                    /* |mapped - target| */
+  double anchor_err;                     /* 27-anchor reconstruction residual */
+  double theta;                          /* geocentric colatitude, radians */
+  double phi;                            /* longitude, radians */
+  double r_surface;                      /* surface radius above the source */
+} gf3d_location;
+
+/*
+ * The output time axis and the source time function conversion, decided
+ * before any element is read. nt is the length every output array needs.
+ *
+ * The axis is the stored one extended to the left by whole samples:
+ *     t[i] = t_first + i*dt_sub,   i = 0..nt-1
+ * so t_first is at or just before the requested -t0, never after it.
+ */
+typedef struct {
+  int    nt;               /* samples on the output axis */
+  int    nt_db;            /* samples the database stores */
+  int    npad;             /* samples prepended: nt = nt_db + npad */
+  int    subsample_step;
+  int    khalf;            /* conversion kernel half length, in samples */
+  int    guard;            /* 1 when the requested source is narrower than
+                              the database's own, so no width correction is
+                              possible; the trace is still usable, but its
+                              duration is the database's */
+  int    kind_stf;         /* 0 none, 1 Gaussian, 2 Heaviside */
+  int    pad_;
+  double dt;               /* solver step, s */
+  double dt_sub;           /* stored sample spacing = dt*subsample_step */
+  double t0_db;
+  double t0_req;           /* the start time asked for */
+  double t0;
+  double t_first;          /* t[0] */
+  double hdur_src;         /* the source's own field */
+  double hdur_target;      /* the Gaussian width specfem would use */
+  double hdur_db;          /* the database's Gaussian width */
+  double hdur_corr;        /* sqrt(hdur_target^2 - hdur_db^2) */
+  double trunc;            /* kernel truncation, in units of hdur_corr */
+} gf3d_plan;
+
+/* ------------------------------------------------------------------ */
+/* version, sizes and errors                                          */
+/* ------------------------------------------------------------------ */
+
+/* library version string, e.g. "0.1.0". Truncated to buflen, always
+   null-terminated. */
+int gf3d_version(char *buf, int buflen);
+
+/* c_sizeof of each struct above, so that a binding written against this
+   header can check at load time that it agrees with the library it found.
+   Any pointer may be NULL. */
+int gf3d_sizeof(int *source, int *info, int *station, int *location, int *plan);
+
+/* the message from the most recent failure, process-wide */
+int gf3d_last_error(char *buf, int buflen);
+
+/* a short name for a status code, e.g. "invalid argument" */
+int gf3d_error_string(int code, char *buf, int buflen);
+
+/* ------------------------------------------------------------------ */
+/* opening and interrogating a database                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Open the database rooted at `path` (the directory holding mesh_info.h5,
+ * elements/ and stations/) and write its handle to *h.
+ *
+ * check_completion != 0 verifies that every element/station file the index
+ * promises is present, which costs one stat() per file; xgf3d --info does
+ * this, extraction does not.
+ */
+int gf3d_open(const char *path, int check_completion, gf3d_handle *h);
+
+/* Close a database and release the search tree. Idempotent only in the
+   sense that a second call returns GF_ERR_ARG; it is never an abort. */
+int gf3d_close(gf3d_handle h);
+
+int gf3d_get_info(gf3d_handle h, gf3d_info *info);
+
+/* ista is 0-based, 0 .. info.nstations-1 */
+int gf3d_get_station(gf3d_handle h, int ista, gf3d_station *sta);
+
+/* ------------------------------------------------------------------ */
+/* locating and planning                                              */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Find the element containing a geographic point, and the position in it.
+ * Returns GF_ERR_NO_ELEMENT when the point is outside the database.
+ *
+ * This also loads the topography grid on first use (about 58 MB), which is
+ * why it is worth doing once rather than per extraction if the source does
+ * not move.
+ */
+int gf3d_locate(gf3d_handle h, double lat, double lon, double depth_km,
+                gf3d_location *loc);
+
+/*
+ * The output axis and source time function conversion for a source.
+ *
+ * t0_req is the requested start time in seconds before the centroid time;
+ * pass a negative value for specfem's own rule for a forward run (1.5*hdur
+ * for a moment tensor). Call this first: plan.nt is how long the output
+ * arrays must be.
+ */
+int gf3d_get_plan(gf3d_handle h, const gf3d_source *src, double t0_req,
+                  gf3d_plan *plan);
+
+/* number of partials for itypsokern = 0, 1 or 2: 0, GF_NDP_MT, GF_NDP_LOC */
+int gf3d_ndp(int itypsokern, int *ndp);
+
+/* name ("Mrr" .. "tim") and unit ("m/dyne-cm", "m/deg", "m/km", "m/s") of
+   partial ip, 0-based. Either buffer may be NULL. */
+int gf3d_partial_name(int ip, char *name, int namelen, char *unit, int unitlen);
+
+/* ------------------------------------------------------------------ */
+/* extraction                                                         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Seismograms at every station.
+ *
+ *   nt      must equal plan.nt from gf3d_get_plan() with the same source
+ *           and t0_req
+ *   seis    [nstations][3][nt], metres, N/E/Z          (caller-allocated)
+ *   t       [nt], seconds relative to the centroid time
+ *   onset   [nstations]; the amplitude just before the record starts,
+ *           relative to the trace peak. Anything above ~1e-3 means the
+ *           conversion kernel is reaching back past the beginning of the
+ *           stored record and the first arrivals may be contaminated.
+ *   loc     may be NULL; otherwise receives where the source was located
+ */
+int gf3d_seismograms(gf3d_handle h, const gf3d_source *src, double t0_req,
+                     int nt, double *seis, double *t, double *onset,
+                     gf3d_location *loc);
+
+/*
+ * Seismograms and their partial derivatives, for a moment-tensor source.
+ *
+ *   itypsokern  1 for the six moment-tensor partials, 2 for those plus
+ *               d/d(latitude), d/d(longitude), d/d(depth), d/d(time)
+ *   ndp         must equal gf3d_ndp(itypsokern)
+ *   dp          [nstations][ndp][3][nt]                (caller-allocated)
+ *
+ * The partials are analytic throughout -- no finite differences -- and are
+ * per dyne-cm for slots 0-5, per degree for 6 and 7, per km for 8 and per
+ * second for 9. So sum(moment[v]*dp[.][v][.][.]) over v = 0..5 reproduces
+ * the seismogram, with the CMTSOLUTION's own numbers.
+ *
+ * A force source returns GF_ERR_ARG: there is nothing to differentiate
+ * against a moment tensor.
+ */
+int gf3d_partials(gf3d_handle h, const gf3d_source *src, double t0_req,
+                  int itypsokern, int nt, int ndp,
+                  double *seis, double *dp, double *t, double *onset,
+                  gf3d_location *loc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GF3D_H */

--- a/src/gf3d/gf3d_capi.F90
+++ b/src/gf3d/gf3d_capi.F90
@@ -1,0 +1,1155 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- The C ABI of libgf3d. Its contract is include/gf3d.h, which is the
+!---- document to read first and to keep in step with this file.
+!----
+!---- This is the first bind(C) code in specfem3d_globe -- the tree's other
+!---- C interoperability is all FC_FUNC_ in the other direction, C called
+!---- from Fortran -- so the conventions are set here rather than inherited:
+!----
+!----   * every entry is a *function* returning integer(c_int), one of the
+!----     GF_* codes, and writes its outputs through arguments;
+!----   * the caller allocates every output array; nothing allocatable
+!----     crosses the boundary;
+!----   * strings come in null-terminated as character(kind=c_char),
+!----     dimension(*) and go out as a (buffer, length) pair, truncated and
+!----     always terminated;
+!----   * a nullable output is type(c_ptr), value, tested with
+!----     c_associated. Not `optional`: an optional bind(C) dummy is
+!----     Fortran 2018, and the tests build with -std=f2008;
+!----   * every real that arrives from outside is screened with
+!----     gf_is_finite before anything arithmetic touches it.
+!----
+!---- Why an integer handle rather than an opaque pointer
+!---- -------------------------------------------------
+!---- The stage plan called for type(c_ptr) from c_loc on a saved target.
+!---- An index into a table is used instead, because the whole reason this
+!---- facade exists is that nothing reachable from a Python interpreter may
+!---- crash it: a stale or forged pointer is undefined behaviour, whereas a
+!---- stale or forged index is a bounds test and a GF_ERR_ARG. The cost is a
+!---- fixed ceiling on simultaneously open databases (GF3D_MAX_HANDLES),
+!---- which no caller is near.
+!----
+!---- Why values, not file paths
+!---- --------------------------
+!---- There is deliberately no "open this CMTSOLUTION" entry point. Reading
+!---- one means get_cmt()/get_force(), which stop on malformed input; the
+!---- caller passes numbers instead and gf_source_set_cmt/force applies the
+!---- readers' own arithmetic to them. Parsing the file is the Python side's
+!---- job. See the header of gf_source.F90.
+!----
+!---- Process-wide state, and what it means for a long-lived caller
+!---- ------------------------------------------------------------
+!---- gf_errmsg, the kd-tree in src/shared/search_kdtree.f90, and specfem's
+!---- shared_parameters are all one per process, not one per handle. So:
+!----     - the facade is not thread-safe, and says so in the header;
+!----     - every computing entry re-installs shared_parameters from its own
+!----       handle first, so that opening a second database cannot leave the
+!----       first one indexing a topography grid with the wrong dimensions.
+!----
+
+  module gf3d_capi
+
+  use, intrinsic :: iso_c_binding, only: &
+    c_int, c_double, c_char, c_ptr, c_null_char, c_associated, c_f_pointer, c_sizeof
+
+  use constants, only: MAX_STRING_LEN
+
+  ! GF3D_VERSION is renamed on import: Fortran is case-insensitive, so the
+  ! constant and the gf3d_version() entry point below would otherwise be the
+  ! same name. Renaming the constant rather than the function keeps every
+  ! procedure here spelled exactly like the C symbol it binds.
+  use gf_par, only: t_gfdb, t_gf_source, t_gf_location, t_gf_taxis, t_gf_stf, &
+                    GF_VERSION_STRING => GF3D_VERSION, GF_NCOMP, &
+                    GF_OK, GF_ERR_ARG, GF_ERR_ALLOC, &
+                    GF_SRC_FORCE, GF_SRC_CMT, &
+                    gf_set_error, gf_error_string, gf_errmsg, gf_is_finite
+
+  use gf_shared_params, only: gf_init_shared_params
+
+  use gf_database, only: gf_open, gf_close
+
+  use gf_source, only: gf_source_set_cmt, gf_source_set_force
+
+  use gf_locate, only: gf_locate_source, gf_locate_release
+
+  use gf_seismograms, only: gf_seis_plan, gf_seis, gf_seis_cmt_partials
+
+  use gf_partials, only: gf_partials_ndp, GF_NDP_LOC, GF_DP_NAME, GF_DP_UNIT
+
+  use shared_parameters, only: R_PLANET, RHOAV
+
+  implicit none
+
+  private
+
+  !--- must match include/gf3d.h ---
+  integer, parameter :: GF3D_MAX_HANDLES = 32
+  integer, parameter :: GF3D_STRLEN = 64
+  integer, parameter :: GF3D_MORTON_STRLEN = 24
+
+  !-----------------------------------------------------------------
+  ! the interoperable mirrors of the library's derived types
+  !
+  ! Field for field, and in the same order as the structs in gf3d.h. Note
+  ! the integers are grouped ahead of the doubles, with an explicit pad
+  ! where the count is odd, so that the layout a C compiler chooses and the
+  ! layout gfortran chooses cannot differ by an alignment hole. gf3d_sizeof
+  ! below lets a binding check that at run time rather than trust it.
+  !
+  ! No default initialisation: these are plain data.
+  !-----------------------------------------------------------------
+
+  type, bind(C) :: gf3d_source_t
+    integer(c_int) :: source_type
+    integer(c_int) :: force_stf
+    real(c_double) :: latitude
+    real(c_double) :: longitude
+    real(c_double) :: depth_km
+    real(c_double) :: hdur
+    real(c_double) :: time_shift
+    real(c_double), dimension(6) :: moment
+    real(c_double) :: force_factor
+    real(c_double), dimension(3) :: force_dir
+  end type gf3d_source_t
+
+  type, bind(C) :: gf3d_info_t
+    integer(c_int) :: nelem
+    integer(c_int) :: nstations
+    integer(c_int) :: nstep
+    integer(c_int) :: nt_subsampled
+    integer(c_int) :: subsample_step
+    integer(c_int) :: ngllx, nglly, ngllz
+    integer(c_int) :: topography
+    integer(c_int) :: ellipticity
+    integer(c_int) :: rotation
+    integer(c_int) :: attenuation
+    integer(c_int) :: gravity
+    integer(c_int) :: pad_
+    real(c_double) :: dt
+    real(c_double) :: t0
+    real(c_double) :: r_planet
+    real(c_double) :: rhoav
+    real(c_double) :: scale_displ
+  end type gf3d_info_t
+
+  type, bind(C) :: gf3d_station_t
+    character(kind=c_char), dimension(GF3D_STRLEN) :: id
+    character(kind=c_char), dimension(GF3D_STRLEN) :: network
+    character(kind=c_char), dimension(GF3D_STRLEN) :: station
+    real(c_double) :: latitude
+    real(c_double) :: longitude
+    real(c_double) :: depth_m
+    real(c_double) :: hdur
+    real(c_double) :: f_cutoff
+    real(c_double) :: factor_force_source
+    real(c_double) :: time_shift
+  end type gf3d_station_t
+
+  type, bind(C) :: gf3d_location_t
+    integer(c_int) :: ielem
+    character(kind=c_char), dimension(GF3D_MORTON_STRLEN) :: morton_hex
+    real(c_double) :: xi, eta, gamma
+    real(c_double), dimension(3) :: xyz
+    real(c_double), dimension(3) :: xyz_target
+    real(c_double) :: distance_km
+    real(c_double) :: anchor_err
+    real(c_double) :: theta
+    real(c_double) :: phi
+    real(c_double) :: r_surface
+  end type gf3d_location_t
+
+  type, bind(C) :: gf3d_plan_t
+    integer(c_int) :: nt
+    integer(c_int) :: nt_db
+    integer(c_int) :: npad
+    integer(c_int) :: subsample_step
+    integer(c_int) :: khalf
+    integer(c_int) :: guard
+    integer(c_int) :: kind_stf
+    integer(c_int) :: pad_
+    real(c_double) :: dt
+    real(c_double) :: dt_sub
+    real(c_double) :: t0_db
+    real(c_double) :: t0_req
+    real(c_double) :: t0
+    real(c_double) :: t_first
+    real(c_double) :: hdur_src
+    real(c_double) :: hdur_target
+    real(c_double) :: hdur_db
+    real(c_double) :: hdur_corr
+    real(c_double) :: trunc
+  end type gf3d_plan_t
+
+  !-----------------------------------------------------------------
+  ! the handle table
+  !-----------------------------------------------------------------
+
+  type(t_gfdb), dimension(GF3D_MAX_HANDLES), save :: handles
+  logical, dimension(GF3D_MAX_HANDLES), save :: in_use = .false.
+
+  public :: gf3d_version, gf3d_sizeof, gf3d_last_error, gf3d_error_string
+  public :: gf3d_open, gf3d_close, gf3d_get_info, gf3d_get_station
+  public :: gf3d_locate, gf3d_get_plan, gf3d_ndp, gf3d_partial_name
+  public :: gf3d_seismograms, gf3d_partials
+
+  contains
+
+!
+!===================================================================
+! helpers (not exported)
+!===================================================================
+!
+
+  subroutine put_string(fstr,buf,buflen)
+
+! copies a Fortran string into a C buffer, truncating, always terminating
+
+  implicit none
+
+  character(len=*), intent(in) :: fstr
+  character(kind=c_char), dimension(*), intent(out) :: buf
+  integer, intent(in) :: buflen
+
+  ! local parameters
+  integer :: i,n
+
+  if (buflen < 1) return
+
+  n = min(len_trim(fstr),buflen-1)
+  do i = 1,n
+    buf(i) = fstr(i:i)
+  enddo
+  buf(n+1) = c_null_char
+
+  end subroutine put_string
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine get_string(buf,fstr)
+
+! copies a null-terminated C string into a Fortran string
+!
+! A string longer than fstr is truncated rather than refused; every caller
+! below then fails on the truncated path, which is a clearer error than a
+! length complaint.
+
+  implicit none
+
+  character(kind=c_char), dimension(*), intent(in) :: buf
+  character(len=*), intent(out) :: fstr
+
+  ! local parameters
+  integer :: i
+
+  fstr = ''
+  do i = 1,len(fstr)
+    if (buf(i) == c_null_char) return
+    fstr(i:i) = buf(i)
+  enddo
+
+  end subroutine get_string
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine use_handle(h,ierr)
+
+! validates a handle and re-installs specfem's globals from it
+!
+! The re-installation is the part that is easy to miss: R_PLANET, NX_BATHY,
+! NY_BATHY and RESOLUTION_TOPO_FILE live in shared_parameters, one set per
+! process, and gf_open() writes them. With two databases open, the second
+! open would otherwise leave the first handle's topography grid being
+! indexed with the second's dimensions -- and get_topo_bathy() does not
+! range-check, it returns plausible-looking garbage.
+
+  implicit none
+
+  integer(c_int), intent(in) :: h
+  integer, intent(out) :: ierr
+
+  if (h < 1 .or. h > GF3D_MAX_HANDLES) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d: handle out of range')
+    return
+  endif
+
+  if (.not. in_use(h)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d: handle is not open')
+    return
+  endif
+
+  call gf_init_shared_params(handles(h),ierr)
+
+  end subroutine use_handle
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine build_source(csrc,db,src,ierr)
+
+! turns the C struct into the library's own source type
+
+  implicit none
+
+  type(gf3d_source_t), intent(in) :: csrc
+  type(t_gfdb), intent(in) :: db
+  type(t_gf_source), intent(out) :: src
+  integer, intent(out) :: ierr
+
+  select case (csrc%source_type)
+  case (GF_SRC_CMT)
+    call gf_source_set_cmt(src,csrc%latitude,csrc%longitude,csrc%depth_km, &
+                           csrc%hdur,csrc%time_shift,csrc%moment,db%dt,ierr)
+  case (GF_SRC_FORCE)
+    call gf_source_set_force(src,csrc%latitude,csrc%longitude,csrc%depth_km, &
+                             csrc%hdur,csrc%time_shift,int(csrc%force_stf), &
+                             csrc%force_factor, &
+                             csrc%force_dir(1),csrc%force_dir(2),csrc%force_dir(3), &
+                             db%dt,ierr)
+  case default
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d: source_type must be GF_SRC_CMT (2) or GF_SRC_FORCE (1)')
+  end select
+
+  end subroutine build_source
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine fill_location(loc,cloc)
+
+  implicit none
+
+  type(t_gf_location), intent(in) :: loc
+  type(gf3d_location_t), intent(out) :: cloc
+
+  cloc%ielem = int(loc%ielem,kind=c_int)
+  call put_string(loc%morton_hex,cloc%morton_hex,GF3D_MORTON_STRLEN)
+  cloc%xi = loc%xi
+  cloc%eta = loc%eta
+  cloc%gamma = loc%gamma
+  cloc%xyz(1:3) = loc%xyz(1:3)
+  cloc%xyz_target(1:3) = loc%xyz_target(1:3)
+  cloc%distance_km = loc%distance_km
+  cloc%anchor_err = loc%anchor_err
+  cloc%theta = loc%theta
+  cloc%phi = loc%phi
+  cloc%r_surface = loc%r_surface
+
+  end subroutine fill_location
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine fill_plan(tax,stf,t0_req,cplan)
+
+  implicit none
+
+  type(t_gf_taxis), intent(in) :: tax
+  type(t_gf_stf), intent(in) :: stf
+  double precision, intent(in) :: t0_req
+  type(gf3d_plan_t), intent(out) :: cplan
+
+  cplan%nt = int(tax%nt,kind=c_int)
+  cplan%nt_db = int(tax%nt_db,kind=c_int)
+  cplan%npad = int(tax%npad,kind=c_int)
+  cplan%subsample_step = int(tax%subsample_step,kind=c_int)
+  cplan%khalf = int(stf%khalf,kind=c_int)
+  cplan%guard = 0
+  if (stf%guard) cplan%guard = 1
+  cplan%kind_stf = int(stf%kind_stf,kind=c_int)
+  cplan%pad_ = 0
+  cplan%dt = tax%dt
+  cplan%dt_sub = tax%dt_sub
+  cplan%t0_db = tax%t0_db
+  cplan%t0_req = t0_req
+  cplan%t0 = tax%t0
+  cplan%t_first = tax%t_first
+  cplan%hdur_src = stf%hdur_src
+  cplan%hdur_target = stf%hdur_target
+  cplan%hdur_db = stf%hdur_db
+  cplan%hdur_corr = stf%hdur_corr
+  cplan%trunc = stf%trunc
+
+  end subroutine fill_plan
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine pack_seis(nsta,nt,seis,seis_c)
+
+! (nsta,3,nt) Fortran-ordered -> [ista][icomp][it] C-ordered
+!
+! One copy, made here rather than left to the caller, so that a C or numpy
+! user indexes seis[ista][icomp][it] with no transposition of their own.
+
+  implicit none
+
+  integer, intent(in) :: nsta,nt
+  double precision, dimension(nsta,GF_NCOMP,nt), intent(in) :: seis
+  real(c_double), dimension(nt,GF_NCOMP,nsta), intent(out) :: seis_c
+
+  ! local parameters
+  integer :: ista,icomp,it
+
+  do ista = 1,nsta
+    do icomp = 1,GF_NCOMP
+      do it = 1,nt
+        seis_c(it,icomp,ista) = seis(ista,icomp,it)
+      enddo
+    enddo
+  enddo
+
+  end subroutine pack_seis
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine pack_dp(ndp,nsta,nt,dp,dp_c)
+
+! (ndp,nsta,3,nt) Fortran-ordered -> [ista][ip][icomp][it] C-ordered
+
+  implicit none
+
+  integer, intent(in) :: ndp,nsta,nt
+  double precision, dimension(ndp,nsta,GF_NCOMP,nt), intent(in) :: dp
+  real(c_double), dimension(nt,GF_NCOMP,ndp,nsta), intent(out) :: dp_c
+
+  ! local parameters
+  integer :: ista,icomp,it,ip
+
+  do ista = 1,nsta
+    do ip = 1,ndp
+      do icomp = 1,GF_NCOMP
+        do it = 1,nt
+          dp_c(it,icomp,ip,ista) = dp(ip,ista,icomp,it)
+        enddo
+      enddo
+    enddo
+  enddo
+
+  end subroutine pack_dp
+
+!
+!===================================================================
+! version, sizes and errors
+!===================================================================
+!
+
+  integer(c_int) function gf3d_version(buf,buflen) bind(C,name='gf3d_version')
+
+  implicit none
+
+  character(kind=c_char), dimension(*), intent(out) :: buf
+  integer(c_int), value :: buflen
+
+  call put_string(GF_VERSION_STRING,buf,int(buflen))
+
+  gf3d_version = GF_OK
+
+  end function gf3d_version
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_sizeof(source,info,station,location,plan) bind(C,name='gf3d_sizeof')
+
+! the size of each interoperable struct, so that a binding written against
+! gf3d.h can check at load time that it agrees with the library it found
+!
+! Any argument may be NULL.
+
+  implicit none
+
+  type(c_ptr), value :: source,info,station,location,plan
+
+  ! local parameters
+  integer(c_int), pointer :: p
+  type(gf3d_source_t) :: a
+  type(gf3d_info_t) :: b
+  type(gf3d_station_t) :: c
+  type(gf3d_location_t) :: d
+  type(gf3d_plan_t) :: e
+
+  if (c_associated(source)) then
+    call c_f_pointer(source,p) ; p = int(c_sizeof(a),kind=c_int)
+  endif
+  if (c_associated(info)) then
+    call c_f_pointer(info,p) ; p = int(c_sizeof(b),kind=c_int)
+  endif
+  if (c_associated(station)) then
+    call c_f_pointer(station,p) ; p = int(c_sizeof(c),kind=c_int)
+  endif
+  if (c_associated(location)) then
+    call c_f_pointer(location,p) ; p = int(c_sizeof(d),kind=c_int)
+  endif
+  if (c_associated(plan)) then
+    call c_f_pointer(plan,p) ; p = int(c_sizeof(e),kind=c_int)
+  endif
+
+  gf3d_sizeof = GF_OK
+
+  end function gf3d_sizeof
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_last_error(buf,buflen) bind(C,name='gf3d_last_error')
+
+  implicit none
+
+  character(kind=c_char), dimension(*), intent(out) :: buf
+  integer(c_int), value :: buflen
+
+  call put_string(gf_errmsg,buf,int(buflen))
+
+  gf3d_last_error = GF_OK
+
+  end function gf3d_last_error
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_error_string(code,buf,buflen) bind(C,name='gf3d_error_string')
+
+  implicit none
+
+  integer(c_int), value :: code
+  character(kind=c_char), dimension(*), intent(out) :: buf
+  integer(c_int), value :: buflen
+
+  call put_string(gf_error_string(int(code)),buf,int(buflen))
+
+  gf3d_error_string = GF_OK
+
+  end function gf3d_error_string
+
+!
+!===================================================================
+! opening and interrogating a database
+!===================================================================
+!
+
+  integer(c_int) function gf3d_open(path,check_completion,h) bind(C,name='gf3d_open')
+
+  implicit none
+
+  character(kind=c_char), dimension(*), intent(in) :: path
+  integer(c_int), value :: check_completion
+  integer(c_int), intent(out) :: h
+
+  ! local parameters
+  character(len=MAX_STRING_LEN) :: fpath
+  integer :: islot,i,ierr
+
+  h = 0
+
+  call get_string(path,fpath)
+
+  if (len_trim(fpath) == 0) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_open: no database path given')
+    gf3d_open = int(ierr,kind=c_int)
+    return
+  endif
+
+  islot = 0
+  do i = 1,GF3D_MAX_HANDLES
+    if (.not. in_use(i)) then
+      islot = i
+      exit
+    endif
+  enddo
+
+  if (islot == 0) then
+    call gf_set_error(ierr,GF_ERR_ALLOC,'gf3d_open: too many databases open at once')
+    gf3d_open = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_open(trim(fpath),handles(islot),ierr,check_completion = (check_completion /= 0))
+
+  if (ierr /= GF_OK) then
+    ! gf_open closes what it opened; the slot stays free
+    gf3d_open = int(ierr,kind=c_int)
+    return
+  endif
+
+  in_use(islot) = .true.
+  h = int(islot,kind=c_int)
+
+  gf3d_open = GF_OK
+
+  end function gf3d_open
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_close(h) bind(C,name='gf3d_close')
+
+! closes a database and releases the process-wide search tree
+!
+! The tree is released unconditionally, even when another handle is still
+! open: it belongs to whichever database located last, and the next locate
+! rebuilds it for whoever asks. Leaking it instead would leave
+! src/shared/search_kdtree.f90's module arrays allocated for the life of a
+! Python interpreter.
+
+  implicit none
+
+  integer(c_int), value :: h
+
+  ! local parameters
+  integer :: ierr
+
+  if (h < 1 .or. h > GF3D_MAX_HANDLES) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_close: handle out of range')
+    gf3d_close = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (.not. in_use(h)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_close: handle is not open')
+    gf3d_close = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_locate_release()
+  call gf_close(handles(h))
+
+  in_use(h) = .false.
+
+  gf3d_close = GF_OK
+
+  end function gf3d_close
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_get_info(h,info) bind(C,name='gf3d_get_info')
+
+  implicit none
+
+  integer(c_int), value :: h
+  type(gf3d_info_t), intent(out) :: info
+
+  ! local parameters
+  integer :: ierr
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_get_info = int(ierr,kind=c_int)
+    return
+  endif
+
+  info%nelem          = int(handles(h)%nelem,kind=c_int)
+  info%nstations      = int(handles(h)%nstations,kind=c_int)
+  info%nstep          = int(handles(h)%nstep,kind=c_int)
+  info%nt_subsampled  = int(handles(h)%nt_subsampled,kind=c_int)
+  info%subsample_step = int(handles(h)%subsample_step,kind=c_int)
+  info%ngllx          = int(handles(h)%ngllx,kind=c_int)
+  info%nglly          = int(handles(h)%nglly,kind=c_int)
+  info%ngllz          = int(handles(h)%ngllz,kind=c_int)
+
+  info%topography  = 0 ; if (handles(h)%topography)  info%topography  = 1
+  info%ellipticity = 0 ; if (handles(h)%ellipticity) info%ellipticity = 1
+  info%rotation    = 0 ; if (handles(h)%rotation)    info%rotation    = 1
+  info%attenuation = 0 ; if (handles(h)%attenuation) info%attenuation = 1
+  info%gravity     = 0 ; if (handles(h)%gravity)     info%gravity     = 1
+  info%pad_        = 0
+
+  info%dt          = handles(h)%dt
+  info%t0          = handles(h)%t0
+  info%scale_displ = handles(h)%scale_displ
+
+  ! the values the library is actually using, not the (possibly zero) ones
+  ! the database recorded: the current writer stores neither RHOAV nor the
+  ! flattening, so these fall back to specfem's Earth defaults
+  info%r_planet = R_PLANET
+  info%rhoav    = RHOAV
+
+  gf3d_get_info = GF_OK
+
+  end function gf3d_get_info
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_get_station(h,ista,sta) bind(C,name='gf3d_get_station')
+
+! ista is 0-based, as C expects; the Fortran array below is 1-based
+
+  implicit none
+
+  integer(c_int), value :: h
+  integer(c_int), value :: ista
+  type(gf3d_station_t), intent(out) :: sta
+
+  ! local parameters
+  integer :: ierr,i
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_get_station = int(ierr,kind=c_int)
+    return
+  endif
+
+  i = int(ista) + 1
+
+  if (i < 1 .or. i > handles(h)%nstations) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_get_station: station index out of range')
+    gf3d_get_station = int(ierr,kind=c_int)
+    return
+  endif
+
+  call put_string(handles(h)%stations(i)%id,sta%id,GF3D_STRLEN)
+  call put_string(handles(h)%stations(i)%network,sta%network,GF3D_STRLEN)
+  call put_string(handles(h)%stations(i)%station,sta%station,GF3D_STRLEN)
+
+  sta%latitude            = handles(h)%stations(i)%latitude
+  sta%longitude           = handles(h)%stations(i)%longitude
+  sta%depth_m             = handles(h)%stations(i)%depth
+  sta%hdur                = handles(h)%stations(i)%hdur
+  sta%f_cutoff            = handles(h)%stations(i)%f_cutoff
+  sta%factor_force_source = handles(h)%stations(i)%factor_force_source
+  sta%time_shift          = handles(h)%stations(i)%time_shift
+
+  gf3d_get_station = GF_OK
+
+  end function gf3d_get_station
+
+!
+!===================================================================
+! locating and planning
+!===================================================================
+!
+
+  integer(c_int) function gf3d_locate(h,lat,lon,depth_km,loc) bind(C,name='gf3d_locate')
+
+  implicit none
+
+  integer(c_int), value :: h
+  real(c_double), value :: lat,lon,depth_km
+  type(gf3d_location_t), intent(out) :: loc
+
+  ! local parameters
+  type(t_gf_location) :: floc
+  integer :: ierr
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_locate = int(ierr,kind=c_int)
+    return
+  endif
+
+  ! a NaN would pass reduce()'s range test -- both comparisons are false --
+  ! and reach the kd-tree, which stops when it finds no point
+  if (.not. (gf_is_finite(lat) .and. gf_is_finite(lon) .and. gf_is_finite(depth_km))) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_locate: latitude, longitude or depth is not finite')
+    gf3d_locate = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_locate_source(handles(h),lat,lon,depth_km,floc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_locate = int(ierr,kind=c_int)
+    return
+  endif
+
+  call fill_location(floc,loc)
+
+  gf3d_locate = GF_OK
+
+  end function gf3d_locate
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_get_plan(h,src,t0_req,plan) bind(C,name='gf3d_get_plan')
+
+  implicit none
+
+  integer(c_int), value :: h
+  type(gf3d_source_t), intent(in) :: src
+  real(c_double), value :: t0_req
+  type(gf3d_plan_t), intent(out) :: plan
+
+  ! local parameters
+  type(t_gf_source) :: fsrc
+  type(t_gf_taxis) :: tax
+  type(t_gf_stf) :: stf
+  integer :: ierr
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_get_plan = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (.not. gf_is_finite(t0_req)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_get_plan: t0 is not finite')
+    gf3d_get_plan = int(ierr,kind=c_int)
+    return
+  endif
+
+  call build_source(src,handles(h),fsrc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_get_plan = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_seis_plan(handles(h),fsrc,t0_req,tax,stf,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_get_plan = int(ierr,kind=c_int)
+    return
+  endif
+
+  call fill_plan(tax,stf,t0_req,plan)
+
+  gf3d_get_plan = GF_OK
+
+  end function gf3d_get_plan
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_ndp(itypsokern,ndp) bind(C,name='gf3d_ndp')
+
+  implicit none
+
+  integer(c_int), value :: itypsokern
+  integer(c_int), intent(out) :: ndp
+
+  ! local parameters
+  integer :: n,ierr
+
+  call gf_partials_ndp(int(itypsokern),n,ierr)
+
+  ndp = int(n,kind=c_int)
+
+  gf3d_ndp = int(ierr,kind=c_int)
+
+  end function gf3d_ndp
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_partial_name(ip,name,namelen,unit,unitlen) &
+    bind(C,name='gf3d_partial_name')
+
+! ip is 0-based; either buffer may be NULL
+
+  implicit none
+
+  integer(c_int), value :: ip
+  type(c_ptr), value :: name
+  integer(c_int), value :: namelen
+  type(c_ptr), value :: unit
+  integer(c_int), value :: unitlen
+
+  ! local parameters
+  character(kind=c_char), dimension(:), pointer :: buf
+  integer :: i,ierr
+
+  i = int(ip) + 1
+
+  if (i < 1 .or. i > GF_NDP_LOC) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_partial_name: partial index out of range')
+    gf3d_partial_name = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (c_associated(name) .and. namelen > 0) then
+    call c_f_pointer(name,buf,(/ int(namelen) /))
+    call put_string(GF_DP_NAME(i),buf,int(namelen))
+  endif
+
+  if (c_associated(unit) .and. unitlen > 0) then
+    call c_f_pointer(unit,buf,(/ int(unitlen) /))
+    call put_string(GF_DP_UNIT(i),buf,int(unitlen))
+  endif
+
+  gf3d_partial_name = GF_OK
+
+  end function gf3d_partial_name
+
+!
+!===================================================================
+! extraction
+!===================================================================
+!
+
+  integer(c_int) function gf3d_seismograms(h,src,t0_req,nt,seis,t,onset,loc) &
+    bind(C,name='gf3d_seismograms')
+
+! seismograms at every station, in C order [ista][icomp][it]
+!
+! Mirrors gf3d_main.F90's --seis path exactly: locate (which also loads the
+! topography grid, lazily), plan, extract. `loc` may be NULL.
+
+  implicit none
+
+  integer(c_int), value :: h
+  type(gf3d_source_t), intent(in) :: src
+  real(c_double), value :: t0_req
+  integer(c_int), value :: nt
+  real(c_double), dimension(*), intent(out) :: seis
+  real(c_double), dimension(*), intent(out) :: t
+  real(c_double), dimension(*), intent(out) :: onset
+  type(c_ptr), value :: loc
+
+  ! local parameters
+  type(t_gf_source) :: fsrc
+  type(t_gf_location) :: floc
+  type(gf3d_location_t), pointer :: ploc
+  type(t_gf_taxis) :: tax
+  type(t_gf_stf) :: stf
+  double precision, dimension(:,:,:), allocatable :: fseis
+  double precision, dimension(:), allocatable :: ft,fonset
+  integer :: ierr,ier,nsta,it,ista
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (.not. gf_is_finite(t0_req)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_seismograms: t0 is not finite')
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  call build_source(src,handles(h),fsrc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_locate_source(handles(h),fsrc%latitude,fsrc%longitude,fsrc%depth,floc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_seis_plan(handles(h),fsrc,t0_req,tax,stf,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (int(nt) /= tax%nt) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d_seismograms: nt does not match the plan; call gf3d_get_plan first')
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  nsta = handles(h)%nstations
+
+  allocate(fseis(nsta,GF_NCOMP,tax%nt),ft(tax%nt),fonset(nsta),stat=ier)
+  if (ier /= 0) then
+    call gf_set_error(ierr,GF_ERR_ALLOC,'gf3d_seismograms: could not allocate the work arrays')
+    gf3d_seismograms = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_seis(handles(h),fsrc,floc,tax,stf,fseis,ft,fonset,ierr)
+
+  if (ierr == GF_OK) then
+    call pack_seis(nsta,tax%nt,fseis,seis)
+    do it = 1,tax%nt
+      t(it) = ft(it)
+    enddo
+    do ista = 1,nsta
+      onset(ista) = fonset(ista)
+    enddo
+    if (c_associated(loc)) then
+      call c_f_pointer(loc,ploc)
+      call fill_location(floc,ploc)
+    endif
+  endif
+
+  deallocate(fseis,ft,fonset)
+
+  gf3d_seismograms = int(ierr,kind=c_int)
+
+  end function gf3d_seismograms
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  integer(c_int) function gf3d_partials(h,src,t0_req,itypsokern,nt,ndp, &
+                                        seis,dp,t,onset,loc) bind(C,name='gf3d_partials')
+
+! seismograms and their partial derivatives, in C order
+! [ista][icomp][it] and [ista][ip][icomp][it]
+
+  implicit none
+
+  integer(c_int), value :: h
+  type(gf3d_source_t), intent(in) :: src
+  real(c_double), value :: t0_req
+  integer(c_int), value :: itypsokern
+  integer(c_int), value :: nt
+  integer(c_int), value :: ndp
+  real(c_double), dimension(*), intent(out) :: seis
+  real(c_double), dimension(*), intent(out) :: dp
+  real(c_double), dimension(*), intent(out) :: t
+  real(c_double), dimension(*), intent(out) :: onset
+  type(c_ptr), value :: loc
+
+  ! local parameters
+  type(t_gf_source) :: fsrc
+  type(t_gf_location) :: floc
+  type(gf3d_location_t), pointer :: ploc
+  type(t_gf_taxis) :: tax
+  type(t_gf_stf) :: stf
+  double precision, dimension(:,:,:), allocatable :: fseis
+  double precision, dimension(:,:,:,:), allocatable :: fdp
+  double precision, dimension(:), allocatable :: ft,fonset
+  integer :: ierr,ier,nsta,ndp_want,it,ista
+
+  call use_handle(h,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (.not. gf_is_finite(t0_req)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf3d_partials: t0 is not finite')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (int(itypsokern) < 1) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d_partials: itypsokern must be 1 or 2; use gf3d_seismograms for 0')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_partials_ndp(int(itypsokern),ndp_want,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (int(ndp) /= ndp_want) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d_partials: ndp does not match itypsokern; ask gf3d_ndp for it')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  call build_source(src,handles(h),fsrc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (fsrc%source_type /= GF_SRC_CMT) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d_partials: partial derivatives are defined for a moment-tensor source only')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_locate_source(handles(h),fsrc%latitude,fsrc%longitude,fsrc%depth,floc,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_seis_plan(handles(h),fsrc,t0_req,tax,stf,ierr)
+  if (ierr /= GF_OK) then
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  if (int(nt) /= tax%nt) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf3d_partials: nt does not match the plan; call gf3d_get_plan first')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  nsta = handles(h)%nstations
+
+  allocate(fseis(nsta,GF_NCOMP,tax%nt),fdp(ndp_want,nsta,GF_NCOMP,tax%nt), &
+           ft(tax%nt),fonset(nsta),stat=ier)
+  if (ier /= 0) then
+    call gf_set_error(ierr,GF_ERR_ALLOC,'gf3d_partials: could not allocate the work arrays')
+    gf3d_partials = int(ierr,kind=c_int)
+    return
+  endif
+
+  call gf_seis_cmt_partials(handles(h),fsrc,floc,tax,stf,int(itypsokern),ndp_want, &
+                            fseis,fdp,ft,fonset,ierr)
+
+  if (ierr == GF_OK) then
+    call pack_seis(nsta,tax%nt,fseis,seis)
+    call pack_dp(ndp_want,nsta,tax%nt,fdp,dp)
+    do it = 1,tax%nt
+      t(it) = ft(it)
+    enddo
+    do ista = 1,nsta
+      onset(ista) = fonset(ista)
+    enddo
+    if (c_associated(loc)) then
+      call c_f_pointer(loc,ploc)
+      call fill_location(floc,ploc)
+    endif
+  endif
+
+  deallocate(fseis,fdp,ft,fonset)
+
+  gf3d_partials = int(ierr,kind=c_int)
+
+  end function gf3d_partials
+
+  end module gf3d_capi

--- a/src/gf3d/gf_database.F90
+++ b/src/gf3d/gf_database.F90
@@ -810,33 +810,10 @@
 !-------------------------------------------------------------------------------------------------
 !
 
-  logical function gf_is_finite(x)
-
-! true when x is neither NaN nor infinite
-!
-! Written as a bit test rather than with ieee_is_finite() because the
-! intrinsic IEEE modules are not universally available — the Red Hat
-! gcc-toolset gfortran packages, among others, ship without them — and
-! because a comparison against a NaN is itself an invalid operation under
-! -ffpe-trap=invalid. transfer() and iand() touch no floating-point unit.
-!
-! An IEEE-754 binary64 is NaN or infinite exactly when its 11 exponent
-! bits (52..62) are all set. ISHFT is defined as a *logical* shift, so the
-! sign bit does not smear into the result.
-
-  implicit none
-
-  double precision, intent(in) :: x
-
-  ! local parameters
-  integer(kind=8) :: bits
-  integer(kind=8), parameter :: EXPONENT_MASK = 2047_8
-
-  bits = transfer(x,bits)
-
-  gf_is_finite = (iand(ishft(bits,-52),EXPONENT_MASK) /= EXPONENT_MASK)
-
-  end function gf_is_finite
+! gf_is_finite() moved to gf_par in Stage 9: the C facade screens every
+! value that crosses the boundary with it, and gf_source (a kernel module,
+! below the HDF5 tier) needs it too. It is used unchanged here, by use
+! association.
 
 !
 !-------------------------------------------------------------------------------------------------

--- a/src/gf3d/gf_par.F90
+++ b/src/gf3d/gf_par.F90
@@ -464,4 +464,66 @@
 
   end function gf_error_string
 
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  logical function gf_is_finite(x)
+
+! true when x is neither NaN nor infinite
+!
+! Written as a bit test rather than with ieee_is_finite() because the
+! intrinsic IEEE modules are not universally available — the Red Hat
+! gcc-toolset gfortran packages, among others, ship without them — and
+! because a comparison against a NaN is itself an invalid operation under
+! -ffpe-trap=invalid. transfer() and iand() touch no floating-point unit.
+!
+! An IEEE-754 binary64 is NaN or infinite exactly when its 11 exponent
+! bits (52..62) are all set. ISHFT is defined as a *logical* shift, so the
+! sign bit does not smear into the result.
+!
+! Lives here rather than in gf_database (where it was written, to screen
+! centroids.bin) because every value that enters the library from outside
+! is screened with it: a NaN reaching gf_locate would pass reduce()'s
+! range test — both comparisons are false — and reach the kd-tree, whose
+! "found no point" branch is a stop, which inside a .so takes the calling
+! interpreter with it.
+
+  implicit none
+
+  double precision, intent(in) :: x
+
+  ! local parameters
+  integer(kind=8) :: bits
+  integer(kind=8), parameter :: EXPONENT_MASK = 2047_8
+
+  bits = transfer(x,bits)
+
+  gf_is_finite = (iand(ishft(bits,-52),EXPONENT_MASK) /= EXPONENT_MASK)
+
+  end function gf_is_finite
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  logical function gf_all_finite(x)
+
+! true when every element of x is neither NaN nor infinite
+
+  implicit none
+
+  double precision, dimension(:), intent(in) :: x
+
+  ! local parameters
+  integer :: i
+
+  gf_all_finite = .false.
+  do i = 1,size(x)
+    if (.not. gf_is_finite(x(i))) return
+  enddo
+  gf_all_finite = .true.
+
+  end function gf_all_finite
+
   end module gf_par

--- a/src/gf3d/gf_source.F90
+++ b/src/gf3d/gf_source.F90
@@ -54,21 +54,35 @@
 !----   the centroid time. Those seconds are origin-time metadata for Stage
 !----   10's SAC headers, not part of the trace.
 !----
-!---- Known wart, deferred to Stage 9
-!---- -------------------------------
-!---- get_force `stop`s on malformed input (get_force.f90:240,248,272), which
-!---- breaks this library's no-stop invariant. The common case -- a missing
-!---- file, :103 -- is pre-empted below with an inquire(); the rest need a
-!---- validating pre-pass that would amount to a second parser, and forking
-!---- the reader would give up the scaleF reuse that motivates using it. The
-!---- trade is recorded rather than hidden.
+!---- The `stop`s in the readers, and the way round them (Stage 9)
+!---- -----------------------------------------------------------
+!---- get_force `stop`s on malformed input (get_force.f90:240,248,272) and
+!---- get_cmt on a missing file (:103), which breaks this library's no-stop
+!---- invariant. A `stop` inside lib/libgf3d.so kills the calling Python
+!---- interpreter with no traceback, so the C facade must not be able to
+!---- reach one.
+!----
+!---- The common case -- a missing file -- is pre-empted below with an
+!---- inquire(). For the rest, Stage 9 does not fork the readers (that would
+!---- give up the scaleF/scaleM reuse that motivates using them) and does not
+!---- add a validating pre-pass (that would amount to a second parser).
+!---- Instead the *file* route stays exactly as it is, for xgf3d and for a
+!---- Fortran caller, and the C/Python route never enters it: the caller
+!---- passes values, and gf_source_set_cmt/gf_source_set_force apply the
+!---- readers' own post-parse arithmetic to them, returning an error code
+!---- where the reader would stop. Parsing a CMTSOLUTION is then the Python
+!---- side's job, which is where a malformed file should be diagnosed anyway.
+!----
+!---- The two routes are pinned against each other by tests/gf3d/
+!---- 4d.test_gf_source, at the suite's derived tolerance: they are separate
+!---- compilation units evaluating the same expressions.
 !----
 !---- No `use hdf5`: this is a kernel module.
 !----
 
   module gf_source
 
-  use gf_par, only: t_gf_source,gf_set_error, &
+  use gf_par, only: t_gf_source,gf_set_error,gf_is_finite,gf_all_finite, &
                     GF_OK,GF_ERR_ARG,GF_ERR_NO_FILE,GF_ERR_FORMAT, &
                     GF_SRC_FORCE,GF_SRC_CMT
 
@@ -79,6 +93,8 @@
   public :: gf_read_force_source
   public :: gf_read_cmt_source
   public :: gf_read_source
+  public :: gf_source_set_cmt
+  public :: gf_source_set_force
   public :: gf_detect_source_type
   public :: gf_force_direction
   public :: gf_print_source
@@ -271,6 +287,242 @@
   ierr = GF_OK
 
   end subroutine gf_read_cmt_source
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine gf_source_set_cmt(src,lat,lon,depth_km,hdur,time_shift,moment_dynecm,dt,ierr)
+
+! builds a CMT source from values rather than from a file
+!
+! This is what the C facade calls, so that no path reachable from Python
+! enters get_cmt() and its stop statements (see the module header).
+!
+! Everything get_cmt does to the numbers *after* it has parsed them is
+! applied here, line by line, so that the two routes cannot drift:
+!
+!   get_cmt.f90:397     hdur = max(hdur, 5*DT). Unconditional in the current
+!                       source: the USE_FORCE_POINT_SOURCE branch above it
+!                       (:387-393) is commented out. A null half duration
+!                       means a Heaviside, replaced by a very short error
+!                       function.
+!   get_cmt.f90:405     NOISE_TOMOGRAPHY /= 0 zeroes hdur entirely
+!   get_cmt.f90:408     EXTERNAL_SOURCE_TIME_FUNCTION does the same
+!                       (constants.h:337, .false.); both are no-ops under
+!                       the settings gf_shared_params installs, and both are
+!                       mirrored so that flipping either cannot make the two
+!                       routes disagree
+!   get_cmt.f90:411-413 NSOURCES == 1 zeroes tshift_src and returns the file's
+!                       value in min_tshift_src_original, so t = 0 is the
+!                       centroid time
+!   get_cmt.f90:427-428 scaleM, and the moment tensor divided by it
+!
+! `moment_dynecm` is (Mrr,Mtt,Mpp,Mrt,Mrp,Mtp) in dyne-cm, i.e. the
+! CMTSOLUTION's own numbers and units. `depth_km` is km, `hdur` the raw
+! triangle half duration in seconds, `time_shift` the file's `time shift:`
+! in seconds. `dt` is the database's solver step, needed for the clamp.
+!
+! The PDE header fields and the event name are left blank: they exist for
+! Stage 10's SAC headers, which the in-memory API does not write.
+
+  use constants, only: PI,GRAV,EXTERNAL_SOURCE_TIME_FUNCTION
+
+  use shared_parameters, only: RHOAV,R_PLANET,NOISE_TOMOGRAPHY
+
+  implicit none
+
+  type(t_gf_source), intent(out) :: src
+  double precision, intent(in) :: lat,lon,depth_km,hdur,time_shift,dt
+  double precision, dimension(6), intent(in) :: moment_dynecm
+  integer, intent(out) :: ierr
+
+  ! local parameters
+  double precision :: scale_moment,hdur_use
+
+  src = t_gf_source()
+
+  ! screened before anything arithmetic touches them: a NaN latitude would
+  ! pass reduce()'s range test in gf_locate (both comparisons are false)
+  ! and reach the kd-tree, which stops when it finds no point
+  if (.not. (gf_is_finite(lat) .and. gf_is_finite(lon) .and. gf_is_finite(depth_km) &
+       .and. gf_is_finite(hdur) .and. gf_is_finite(time_shift) .and. gf_is_finite(dt))) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf_source_set_cmt: a source parameter is not finite')
+    return
+  endif
+  if (.not. gf_all_finite(moment_dynecm)) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf_source_set_cmt: a moment tensor component is not finite')
+    return
+  endif
+
+  if (dt <= 0.d0) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf_source_set_cmt: the database time step must be positive')
+    return
+  endif
+
+  if (RHOAV <= 0.d0 .or. R_PLANET <= 0.d0) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf_source_set_cmt: planet constants are unset; open a database first')
+    return
+  endif
+
+  src%source_type = GF_SRC_CMT
+  src%filename = ''
+
+  src%latitude  = lat
+  src%longitude = lon
+  src%depth     = depth_km
+
+  ! get_cmt.f90:397, and then :405/:408
+  hdur_use = hdur
+  if (hdur_use < 5.d0 * dt) hdur_use = 5.d0 * dt
+  if (NOISE_TOMOGRAPHY /= 0) hdur_use = 0.d0
+  if (EXTERNAL_SOURCE_TIME_FUNCTION) hdur_use = 0.d0
+
+  src%hdur = hdur_use
+
+  ! get_cmt.f90:411-413
+  src%tshift_src = 0.d0
+  src%min_tshift_src_original = time_shift
+
+  ! get_cmt.f90:427-428, in get_cmt's own expression from the same module
+  ! variables gf_shared_params set from the database
+  scale_moment = 1.d7 * RHOAV * (R_PLANET**5) * PI*GRAV*RHOAV
+
+  src%moment_tensor(1:6) = moment_dynecm(1:6) / scale_moment
+  src%scale_moment = scale_moment
+
+  ierr = GF_OK
+
+  end subroutine gf_source_set_cmt
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine gf_source_set_force(src,lat,lon,depth_km,f0,time_shift,force_stf, &
+                                 factor_newton,dir_E,dir_N,dir_Z_UP,dt,ierr)
+
+! builds a force source from values rather than from a file
+!
+! The force half of gf_source_set_cmt, and the one that matters more for the
+! no-stop invariant: get_force stops on three malformed inputs, and each of
+! them is an error code here.
+!
+!   get_force.f90:218-249  per force_stf, the half-duration check:
+!                            0, 2, 4  hdur = max(f0, 5*DT)
+!                            1        Ricker, hdur = max(f0, TINYVAL)
+!                            3        monochromatic; f0 < TINYVAL *stops*
+!                            other    *stops*
+!                          (the reader writes `5. * DT`, a default-real
+!                           literal that is exactly 5, so 5.d0*dt agrees
+!                           bit for bit)
+!   get_force.f90:260      a second, unconditional hdur = max(hdur, TINYVAL)
+!   get_force.f90:265-273  a (near) zero-length direction vector *stops*
+!   get_force.f90:277-279  NSOURCES == 1 zeroes tshift_src
+!   get_force.f90:289-290  scaleF, and the factor divided by it
+!
+! `f0` is the FORCESOLUTION's `f0:` field -- a dominant frequency for a
+! Ricker, a Gaussian width otherwise -- which the reader stores in `hdur`.
+! `factor_newton` is `factor force source:` in Newtons. The direction vector
+! has arbitrary length; gf_force_direction normalises it.
+
+  use constants, only: PI,GRAV,TINYVAL
+
+  use shared_parameters, only: RHOAV,R_PLANET
+
+  implicit none
+
+  type(t_gf_source), intent(out) :: src
+  double precision, intent(in) :: lat,lon,depth_km,f0,time_shift
+  integer, intent(in) :: force_stf
+  double precision, intent(in) :: factor_newton,dir_E,dir_N,dir_Z_UP,dt
+  integer, intent(out) :: ierr
+
+  ! local parameters
+  double precision :: scaleF,hdur_use,norm
+
+  src = t_gf_source()
+
+  if (.not. (gf_is_finite(lat) .and. gf_is_finite(lon) .and. gf_is_finite(depth_km) &
+       .and. gf_is_finite(f0) .and. gf_is_finite(time_shift) .and. gf_is_finite(dt) &
+       .and. gf_is_finite(factor_newton) &
+       .and. gf_is_finite(dir_E) .and. gf_is_finite(dir_N) .and. gf_is_finite(dir_Z_UP))) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf_source_set_force: a source parameter is not finite')
+    return
+  endif
+
+  if (dt <= 0.d0) then
+    call gf_set_error(ierr,GF_ERR_ARG,'gf_source_set_force: the database time step must be positive')
+    return
+  endif
+
+  if (RHOAV <= 0.d0 .or. R_PLANET <= 0.d0) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf_source_set_force: planet constants are unset; open a database first')
+    return
+  endif
+
+  ! get_force.f90:218-249, with the two stops turned into error codes
+  hdur_use = f0
+  select case (force_stf)
+  case (0,2,4)
+    ! Gaussian, step, or Meschede Gaussian: a null width means a Dirac,
+    ! replaced by a very short function
+    if (hdur_use < 5.d0 * dt) hdur_use = 5.d0 * dt
+  case (1)
+    ! Ricker: f0 is the dominant frequency
+    if (hdur_use < TINYVAL) hdur_use = TINYVAL
+  case (3)
+    ! monochromatic: f0 is the period, and there is no sensible default
+    if (hdur_use < TINYVAL) then
+      call gf_set_error(ierr,GF_ERR_ARG, &
+        'gf_source_set_force: a monochromatic force (source time function 3) needs a non-zero period')
+      return
+    endif
+  case default
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf_source_set_force: unsupported source time function type (force_stf), expected 0 to 4')
+    return
+  end select
+
+  ! get_force.f90:260
+  if (hdur_use < TINYVAL) hdur_use = TINYVAL
+
+  ! get_force.f90:265-273
+  norm = sqrt(dir_E**2 + dir_N**2 + dir_Z_UP**2)
+  if (norm < TINYVAL) then
+    call gf_set_error(ierr,GF_ERR_ARG, &
+      'gf_source_set_force: the force direction vector has (almost) zero length')
+    return
+  endif
+
+  src%source_type = GF_SRC_FORCE
+  src%filename = ''
+
+  src%latitude  = lat
+  src%longitude = lon
+  src%depth     = depth_km
+
+  src%hdur = hdur_use
+
+  ! get_force.f90:277-279
+  src%tshift_src = 0.d0
+  src%min_tshift_src_original = time_shift
+
+  src%force_stf = force_stf
+
+  ! get_force.f90:289-290
+  scaleF = RHOAV * (R_PLANET**4) * PI*GRAV*RHOAV
+  src%factor_force_source = factor_newton / scaleF
+
+  src%comp_dir_vect_source_E    = dir_E
+  src%comp_dir_vect_source_N    = dir_N
+  src%comp_dir_vect_source_Z_UP = dir_Z_UP
+
+  ierr = GF_OK
+
+  end subroutine gf_source_set_force
 
 !
 !-------------------------------------------------------------------------------------------------

--- a/src/gf3d/rules.mk
+++ b/src/gf3d/rules.mk
@@ -88,12 +88,20 @@ gf3d_KERNEL_SHARED_OBJECTS = \
 	$(EMPTY_MACRO)
 
 ## the parts that read the database, and therefore need HDF5
+##
+## gf3d.gf3d.o is the public Fortran module -- a re-export facade, so that a
+## downstream program needs `use gf3d` and nothing else -- and
+## gf3d_capi.gf3d.o is the bind(C) facade behind include/gf3d.h and the
+## Python package. Both sit here rather than with the kernels because they
+## re-export the database side.
 gf3d_HDF5_OBJECTS = \
 	$O/gf_hdf5_read.gf3d.o \
 	$O/gf_database.gf3d.o \
 	$O/gf_element_io.gf3d.o \
 	$O/gf_locate.gf3d.o \
 	$O/gf_seismograms.gf3d.o \
+	$O/gf3d.gf3d.o \
+	$O/gf3d_capi.gf3d.o \
 	$(EMPTY_MACRO)
 
 ## From src/specfem3D/: the FORCESOLUTION and CMTSOLUTION readers, reused
@@ -169,6 +177,95 @@ gf3d_SHARED_OBJECTS = \
 	$(gf3d_KERNEL_SHARED_OBJECTS) \
 	$(EMPTY_MACRO)
 
+#######################################
+##
+## -fPIC objects, for lib/libgf3d.so
+##
+## A shared object needs every one of its objects compiled -fPIC, and
+## $O/*.shared.o and $O/*.solver.o are not: they belong to the solver's
+## build, which must not change (this is PR 1's invariant, and a global
+## -fPIC would break it).
+##
+## Two halves, and they are handled differently:
+##
+##  - src/gf3d/'s own objects are compiled -fPIC *always*, in place. Nothing
+##    but gf3d links them, position-independent code costs nothing
+##    measurable on x86-64, and a second copy of every gf_*.o would mean a
+##    second copy of every gf_*.mod and a module-file race under `make -j`.
+##
+##  - the src/shared and src/specfem3D sources the library reuses get a
+##    second object suffix, $O/%.gfpic.o, and their module files go into
+##    $O/gfpic/ so that they can never race the solver's own compile of the
+##    same source.
+##
+## The twins are only ever built for the .so; lib/libgf3d.a keeps using the
+## ordinary $O/*.shared.o, so a Fortran or C caller of the static library
+## links exactly what it did before.
+gf3d_PICMODDIR = $O/gfpic
+
+## Module output and search flags for the twins. Deliberately *without*
+## $(FC_MODINC)$O: if a twin is missing a dependency below, it must fail to
+## compile rather than quietly pick up the solver's .mod file from $O.
+FCFLAGS_gfpic = -I${SETUP} $(FC_MODOUT)$(gf3d_PICMODDIR) $(FC_MODINC)$(gf3d_PICMODDIR) -I$B
+
+## Overridable, for a compiler that spells it differently
+## (e.g. `make FC_PICFLAG=-PIC gf3d` for some non-GNU/Intel front ends).
+FC_PICFLAG ?= -fPIC
+CC_PICFLAG ?= -fPIC
+
+gf3d_PIC_SHARED_OBJECTS = \
+	$O/shared_par.gfpic.o \
+	$O/flush_system.gfpic.o \
+	$O/model_topo_bathy.gfpic.o \
+	$O/rthetaphi_xyz.gfpic.o \
+	$O/reduce.gfpic.o \
+	$O/make_ellipticity.gfpic.o \
+	$O/spline_routines.gfpic.o \
+	$O/intgrl.gfpic.o \
+	$O/model_prem.gfpic.o \
+	$O/model_Sohl.gfpic.o \
+	$O/model_vpremoon.gfpic.o \
+	$O/heap_sort.gfpic.o \
+	$O/search_kdtree.gfpic.o \
+	$O/gll_library.gfpic.o \
+	$O/lagrange_poly.gfpic.o \
+	$O/hex_nodes.gfpic.o \
+	$O/recompute_jacobian.gfpic.o \
+	$O/calendar.gfpic.o \
+	$O/binary_c_io.gfpic_cc.o \
+	$O/get_force.gfpic.o \
+	$O/get_cmt.gfpic.o \
+	$(EMPTY_MACRO)
+
+## everything that goes into the shared object: the gf3d objects (already
+## -fPIC) plus the twins, with gf3d_SOLVER_OBJECTS replaced by theirs
+gf3d_PIC_OBJECTS = \
+	$(gf3d_KERNEL_OBJECTS) \
+	$(gf3d_HDF5_OBJECTS) \
+	$(gf3d_PIC_SHARED_OBJECTS) \
+	$(EMPTY_MACRO)
+
+## the public C header and Fortran module, installed for downstream callers
+gf3d_INCDIR = $B/include
+
+gf3d_INCLUDES = \
+	$(gf3d_INCDIR)/gf3d.h \
+	$(gf3d_INCDIR)/gf3d.$(FC_MODEXT) \
+	$(EMPTY_MACRO)
+
+## Appended to gf3d_MODULES so that the central `clean` in Makefile.in
+## removes them. It has to be unconditional: gf3d_TARGETS is empty when the
+## tree was configured without HDF5, and `realclean` clears $E, $O and $L but
+## never include/.
+gf3d_CLEAN_EXTRA = \
+	$L/libgf3d.so \
+	$(gf3d_PIC_SHARED_OBJECTS) \
+	$(gf3d_PICMODDIR)/*.$(FC_MODEXT) \
+	$(gf3d_INCLUDES) \
+	$(EMPTY_MACRO)
+
+#######################################
+
 gf3d_MODULES = \
 	$(FC_MODDIR)/gf_par.$(FC_MODEXT) \
 	$(FC_MODDIR)/gf_hdf5_read.$(FC_MODEXT) \
@@ -187,6 +284,9 @@ gf3d_MODULES = \
 	$(FC_MODDIR)/gf_partials.$(FC_MODEXT) \
 	$(FC_MODDIR)/gf_sac.$(FC_MODEXT) \
 	$(FC_MODDIR)/gf_seismograms.$(FC_MODEXT) \
+	$(FC_MODDIR)/gf3d.$(FC_MODEXT) \
+	$(FC_MODDIR)/gf3d_capi.$(FC_MODEXT) \
+	$(gf3d_CLEAN_EXTRA) \
 	$(EMPTY_MACRO)
 
 #######################################
@@ -200,7 +300,9 @@ ifeq ($(HDF5), yes)
 
 gf3d_TARGETS = \
 	$L/libgf3d.a \
+	$L/libgf3d.so \
 	$E/xgf3d \
+	$(gf3d_INCLUDES) \
 	$(EMPTY_MACRO)
 
 else
@@ -242,6 +344,53 @@ $L/libgf3d.a: $(gf3d_OBJECTS) $(gf3d_SHARED_OBJECTS)
 $E/xgf3d: $(gf3d_PROGRAM_OBJECTS) $L/libgf3d.a
 	${FCCOMPILE_CHECK} -o $@ $(gf3d_PROGRAM_OBJECTS) $L/libgf3d.a $(LDFLAGS)
 
+####
+#### the shared object, for ctypes and for any C caller that dlopen()s us
+####
+
+## The HDF5 library directories are baked in as an rpath, so that
+## `ctypes.CDLL("libgf3d.so")` resolves them with no LD_LIBRARY_PATH set --
+## a Python user has no reason to know where this tree's HDF5 came from.
+## $(LDFLAGS) is where configure put them (Makefile.in, COND_HDF5).
+comma := ,
+gf3d_RPATH = $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
+
+## HDF5_USE_SHLIB: when FC is HDF5's own h5fc/h5pfc wrapper, it appends the
+## *static* HDF5 archives by default, and those are not compiled -fPIC, so
+## the shared link dies on the first archive member the linker actually
+## needs (libhdf5_hl, which Makefile.in leaves to the wrapper). Asking the
+## wrapper for the shared libraries instead fixes it at the source. The
+## variable is meaningless to a plain gfortran/ifort, where HDF5_LIBS names
+## the library directory and the .so files carry their own dependencies.
+gf3d_SO_ENV = HDF5_USE_SHLIB=yes
+
+## Note the .so is deliberately *not* in DEFAULT: `make` builds xgf3d, and
+## `make gf3d` builds this as well. A shared link is the one step here that
+## can fail on an unusual toolchain, and it must not take the executable
+## down with it.
+##
+## Note also that with a parallel HDF5 the .so lists libmpi as NEEDED, pulled
+## in transitively by libhdf5 itself, exactly as bin/xgf3d already does. That
+## is HDF5's dependency and not ours; what is ours is checked on the objects,
+## `nm $O/gf_*.o | grep ' U .*mpi_'`, by tests/gf3d/.
+$L/libgf3d.so: $(gf3d_PIC_OBJECTS)
+	@-mkdir -p $L
+	$(gf3d_SO_ENV) ${FCCOMPILE_CHECK} $(FC_PICFLAG) -shared -o $@ $(gf3d_PIC_OBJECTS) $(LDFLAGS) $(gf3d_RPATH)
+
+####
+#### the public header and module
+####
+
+## include/ is created by configure and is gitignored, so the tracked copy of
+## the header lives beside the source it describes and is installed here.
+$(gf3d_INCDIR)/gf3d.h: ${S_TOP}/src/gf3d/gf3d.h
+	@-mkdir -p $(gf3d_INCDIR)
+	cp -f $< $@
+
+$(gf3d_INCDIR)/gf3d.$(FC_MODEXT): $O/gf3d.gf3d.o
+	@-mkdir -p $(gf3d_INCDIR)
+	cp -f $(FC_MODDIR)/gf3d.$(FC_MODEXT) $@
+
 #######################################
 
 ## compilation directories
@@ -274,17 +423,56 @@ $O/gf_seismograms.gf3d.o: $O/gf_par.gf3d.o $O/gf_database.gf3d.o $O/gf_element_i
                           $O/gf_interp.gf3d.o $O/gf_source.gf3d.o $O/gf_strain.gf3d.o \
                           $O/gf_moment.gf3d.o $O/gf_stf.gf3d.o $O/gf_partials.gf3d.o \
                           $O/gf_geo_chain.gf3d.o
+$O/gf3d.gf3d.o: $O/gf_par.gf3d.o $O/gf_database.gf3d.o $O/gf_locate.gf3d.o \
+                $O/gf_source.gf3d.o $O/gf_seismograms.gf3d.o $O/gf_partials.gf3d.o \
+                $O/gf_sac.gf3d.o $O/gf_shared_params.gf3d.o
+$O/gf3d_capi.gf3d.o: $O/gf_par.gf3d.o $O/gf_database.gf3d.o $O/gf_locate.gf3d.o \
+                     $O/gf_source.gf3d.o $O/gf_seismograms.gf3d.o $O/gf_partials.gf3d.o \
+                     $O/gf_shared_params.gf3d.o
 $O/gf3d_main.gf3d.o: $O/gf_par.gf3d.o $O/gf_database.gf3d.o $O/gf_locate.gf3d.o \
                      $O/gf_source.gf3d.o $O/gf_seismograms.gf3d.o $O/gf_partials.gf3d.o \
                      $O/gf_sac.gf3d.o
 
 ## unique object suffix: every rules.mk writes into the same $O, so the
 ## pattern rules of different subdirectories must not collide
+##
+## $(FC_PICFLAG): these objects go into lib/libgf3d.so as well as into
+## lib/libgf3d.a, and nothing outside src/gf3d/ links them -- see the
+## -fPIC section above.
 $O/%.gf3d.o: $S/%.f90 $O/shared_par.shared_module.o
-	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} $(FC_PICFLAG) -c -o $@ $<
 
 $O/%.gf3d.o: $S/%.F90 $O/shared_par.shared_module.o
-	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} $(FC_PICFLAG) -c -o $@ $<
 
 $O/%.gf3d_cc.o: $S/%.c ${SETUP}/config.h
-	${CC} -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
+	${CC} -c $(CPPFLAGS) $(CFLAGS) $(CC_PICFLAG) -o $@ $<
+
+####
+#### the -fPIC twins of the src/shared and src/specfem3D sources
+####
+
+$(gf3d_PICMODDIR):
+	@-mkdir -p $@
+
+## shared_par.f90 defines `constants` and `shared_parameters`, which every
+## other twin uses, so it is named explicitly: the pattern rule below would
+## otherwise make it a prerequisite of itself.
+$O/shared_par.gfpic.o: ${S_TOP}/src/shared/shared_par.f90 ${SETUP}/constants.h | $(gf3d_PICMODDIR)
+	${FCCOMPILE_CHECK} $(FCFLAGS_gfpic) $(FC_PICFLAG) -c -o $@ $<
+
+## the only inter-twin module dependency in the whole set: every other source
+## here uses nothing but `constants`/`shared_parameters` or a module defined
+## in its own file. (search_kdtree -> heap_sort and get_cmt -> julian_day are
+## plain calls, so they matter at link time only.)
+## Mirrors src/shared/rules.mk.
+$O/make_ellipticity.gfpic.o: $O/model_prem.gfpic.o $O/model_Sohl.gfpic.o $O/model_vpremoon.gfpic.o
+
+$O/%.gfpic.o: ${S_TOP}/src/shared/%.f90 $O/shared_par.gfpic.o | $(gf3d_PICMODDIR)
+	${FCCOMPILE_CHECK} $(FCFLAGS_gfpic) $(FC_PICFLAG) -c -o $@ $<
+
+$O/%.gfpic.o: ${S_TOP}/src/specfem3D/%.f90 $O/shared_par.gfpic.o | $(gf3d_PICMODDIR)
+	${FCCOMPILE_CHECK} $(FCFLAGS_gfpic) $(FC_PICFLAG) -c -o $@ $<
+
+$O/%.gfpic_cc.o: ${S_TOP}/src/shared/%.c ${SETUP}/config.h
+	${CC} -c $(CPPFLAGS) $(CFLAGS) $(CC_PICFLAG) -o $@ $<

--- a/tests/gf3d/4d.test_gf_source.sh
+++ b/tests/gf3d/4d.test_gf_source.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+###################################################
+#
+# Runs test_gf_source against the HDF5-free build from
+# 0.configure.default_make.sh.
+#
+# No database, no HDF5, no MPI: this is a tier-1 test of the two ways to
+# build a source -- from a file, through the solver's own readers, and from
+# values, as the C facade does -- which must agree. Runs on every commit in
+# CI. See gf3df_integration_plan/testing.md.
+#
+###################################################
+
+testdir=`pwd`
+
+# executable
+var=test_gf_source
+
+#checks if ROOT valid
+if [ -z "${ROOT}" ]; then export ROOT=../../ ; fi
+cd $ROOT/
+srcdir=`pwd`
+cd $testdir/
+
+# title
+echo >> $testdir/results.log
+echo "test: $var" >> $testdir/results.log
+echo >> $testdir/results.log
+echo "directory: `pwd`" >> $testdir/results.log
+
+# needs the kernel objects from 0.configure.default_make.sh
+if [ ! -e ./obj/gf_source.gf3d.o ]; then
+  echo "skipped: no gf3d kernel objects (see 0.configure.default_make.sh)" >> $testdir/results.log
+  echo "skipped: no gf3d kernel objects"
+  exit 0
+fi
+
+# clean
+mkdir -p bin OUTPUT_FILES
+rm -f ./bin/$var
+
+# single compilation
+echo "compilation: $var" >> $testdir/results.log
+make -f $var.makefile $var >> $testdir/results.log 2>&1
+echo "" >> $testdir/results.log
+
+# check
+if [ ! -e ./bin/$var ]; then
+  echo "compilation of $var failed, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+# The kernels are meant to be free of MPI and of HDF5. An accidental
+# `use specfem_par` or `use hdf5` in one of them shows up here long before
+# lib/libgf3d.so would notice.
+echo "checking that $var links no MPI" >> $testdir/results.log
+if nm ./bin/$var | grep -i ' U .*mpi_' >> $testdir/results.log 2>&1; then
+  echo "$var references MPI, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+echo "checking that $var links no HDF5" >> $testdir/results.log
+if nm ./bin/$var | grep -i ' U .*h5[a-z]*_' >> $testdir/results.log 2>&1; then
+  echo "$var references HDF5, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+# runs test
+echo "run: `date`" >> $testdir/results.log
+./bin/$var >> $testdir/results.log 2>$testdir/error.log
+
+# checks exit code
+if [[ $? -ne 0 ]]; then
+  echo "test failed"; echo "error log:"; cat $testdir/error.log; echo ""
+  exit 1
+fi
+
+# checks error output (note: fortran stop returns with a zero-exit code)
+if [[ -s $testdir/error.log ]]; then
+  echo "returned ERROR output:" >> $testdir/results.log
+  cat $testdir/error.log >> $testdir/results.log
+  exit 1
+fi
+rm -f $testdir/error.log
+
+#cleanup
+rm -f bin/$var
+rm -f *.mod ./obj/gf_manufactured.mod
+rm -f ./OUTPUT_FILES/test_gf_source.CMTSOLUTION ./OUTPUT_FILES/test_gf_source.FORCESOLUTION
+# done
+echo "successfully tested: `date`" >> $testdir/results.log

--- a/tests/gf3d/5.configure.hdf5_make.sh
+++ b/tests/gf3d/5.configure.hdf5_make.sh
@@ -100,11 +100,54 @@ fi
 echo "binary exists: $var" >> $testdir/results.log
 echo "library exists: lib/libgf3d.a" >> $testdir/results.log
 
+# Stage 9's products: the shared object, the C header and the public module.
+# A missing one is a build regression, not a reason to skip: `make gf3d`
+# just succeeded, so it promised all four.
+for f in ./lib/libgf3d.so ./include/gf3d.h; do
+  if [ ! -e "$f" ]; then
+    echo "make gf3d did not produce $f, please check..." >> $testdir/results.log
+    exit 1
+  fi
+  echo "exists: $f" >> $testdir/results.log
+done
+
+# the module file's name follows the compiler's own case convention
+if [ ! -e ./include/gf3d.mod ] && [ ! -e ./include/GF3D.mod ]; then
+  echo "make gf3d did not install the public module into include/" >> $testdir/results.log
+  exit 1
+fi
+echo "exists: include/gf3d.mod" >> $testdir/results.log
+
+# the C entry points must actually be exported from the shared object
+echo "checking the exported C symbols" >> $testdir/results.log
+if command -v nm > /dev/null 2>&1; then
+  for sym in gf3d_open gf3d_close gf3d_get_info gf3d_get_station gf3d_locate \
+             gf3d_get_plan gf3d_seismograms gf3d_partials gf3d_last_error gf3d_sizeof; do
+    if ! nm -D --defined-only ./lib/libgf3d.so 2>/dev/null | grep -q " T $sym$"; then
+      echo "libgf3d.so does not export $sym, please check..." >> $testdir/results.log
+      exit 1
+    fi
+  done
+  echo "all C entry points are exported" >> $testdir/results.log
+fi
+
+# The point of baking an rpath into the shared object is that ctypes can
+# load it with no LD_LIBRARY_PATH set. Check that, rather than assuming it.
+if command -v ldd > /dev/null 2>&1; then
+  echo "checking that libgf3d.so resolves HDF5 without LD_LIBRARY_PATH" >> $testdir/results.log
+  env -u LD_LIBRARY_PATH ldd ./lib/libgf3d.so >> $testdir/results.log 2>&1
+  if env -u LD_LIBRARY_PATH ldd ./lib/libgf3d.so 2>/dev/null | grep -i "hdf5.*not found" > /dev/null; then
+    echo "libgf3d.so cannot find HDF5 without LD_LIBRARY_PATH, please check..." >> $testdir/results.log
+    exit 1
+  fi
+fi
+
 # the library itself must reference no MPI symbol. HDF5 may of course be a
 # parallel build and drag libmpi in transitively; that is HDF5's dependency,
-# not ours, so this checks our own objects rather than ldd of the binary.
+# not ours, so this checks our own objects rather than ldd of the binary or
+# of the shared object.
 echo "checking that libgf3d.a references no MPI" >> $testdir/results.log
-if nm ./obj/gf_*.o ./obj/gf3d_main*.o | grep -i ' U .*mpi_' >> $testdir/results.log 2>&1; then
+if nm ./obj/gf_*.o ./obj/gf3d_main*.o ./obj/gf3d_capi*.o | grep -i ' U .*mpi_' >> $testdir/results.log 2>&1; then
   echo "a gf3d object references MPI, please check..." >> $testdir/results.log
   exit 1
 fi

--- a/tests/gf3d/9d.test_gf_capi.sh
+++ b/tests/gf3d/9d.test_gf_capi.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+###################################################
+#
+# Runs test_gf_capi: the C round trip over lib/libgf3d.so and
+# include/gf3d.h, and the assertion that no path through the facade can end
+# the process.
+#
+# Needs the HDF5 build from 5.configure.hdf5_make.sh and one of the example
+# databases, so it skips cleanly on a fresh checkout and in CI, exactly as
+# the other database-backed runners here do.
+#
+###################################################
+
+testdir=`pwd`
+
+# executable
+var=test_gf_capi
+
+#checks if ROOT valid
+if [ -z "${ROOT}" ]; then export ROOT=../../ ; fi
+cd $ROOT/
+srcdir=`pwd`
+cd $testdir/
+
+# title
+echo >> $testdir/results.log
+echo "test: $var" >> $testdir/results.log
+echo >> $testdir/results.log
+echo "directory: `pwd`" >> $testdir/results.log
+
+# needs the shared library and the installed header
+if [ ! -e ./lib/libgf3d.so ] || [ ! -e ./include/gf3d.h ]; then
+  echo "skipped: no shared build of libgf3d (see 5.configure.hdf5_make.sh)" >> $testdir/results.log
+  echo "skipped: no shared build of libgf3d"
+  exit 0
+fi
+
+# locates an example database with a validation source
+EX=""
+for cand in "${GF3D_TEST_EXAMPLE}" \
+            "$srcdir/EXAMPLES/green_function_database/regional" \
+            "$srcdir/EXAMPLES/green_function_database/global"; do
+  [ -z "$cand" ] && continue
+  if [ -e "$cand/GFDB/mesh_info.h5" ] && [ -e "$cand/validation_data/CMTSOLUTION" ]; then
+    EX="$cand"; break
+  fi
+done
+
+if [ -z "$EX" ]; then
+  echo "skipped: no built example database (set GF3D_TEST_EXAMPLE)" >> $testdir/results.log
+  echo "skipped: no built example database"
+  exit 0
+fi
+
+GFDB="$EX/GFDB"
+CMT="$EX/validation_data/CMTSOLUTION"
+echo "example: $EX" >> $testdir/results.log
+
+# clean
+mkdir -p bin obj
+rm -f ./bin/$var ./obj/$var.o
+
+# single compilation
+echo "compilation: $var" >> $testdir/results.log
+make -f $var.makefile $var >> $testdir/results.log 2>&1
+echo "" >> $testdir/results.log
+
+# check
+if [ ! -e ./bin/$var ]; then
+  echo "compilation of $var failed, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+# runs test
+echo "run: `date`" >> $testdir/results.log
+./bin/$var "$GFDB" "$CMT" >> $testdir/results.log 2>$testdir/error.log
+
+# checks exit code
+if [[ $? -ne 0 ]]; then
+  echo "test failed"; echo "error log:"; cat $testdir/error.log; echo ""
+  echo "results:"; tail -n 30 $testdir/results.log
+  exit 1
+fi
+
+# checks error output
+if [[ -s $testdir/error.log ]]; then
+  echo "returned ERROR output:" >> $testdir/results.log
+  cat $testdir/error.log >> $testdir/results.log
+  exit 1
+fi
+rm -f $testdir/error.log
+
+#cleanup
+rm -f ./bin/$var ./obj/$var.o
+# done
+echo "successfully tested: `date`" >> $testdir/results.log

--- a/tests/gf3d/9e.test_gf3d_ext.sh
+++ b/tests/gf3d/9e.test_gf3d_ext.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+###################################################
+#
+# Runs test_gf3d_ext: an external Fortran program built the way a
+# downstream caller builds one, against include/ and lib/libgf3d.a only.
+#
+# It checks two things at once -- that `use gf3d` alone is enough, and that
+# the public Fortran API and the C ABI produce the same numbers.
+#
+# Needs the HDF5 build from 5.configure.hdf5_make.sh and one of the example
+# databases, so it skips cleanly on a fresh checkout and in CI.
+#
+###################################################
+
+testdir=`pwd`
+
+# executable
+var=test_gf3d_ext
+
+#checks if ROOT valid
+if [ -z "${ROOT}" ]; then export ROOT=../../ ; fi
+cd $ROOT/
+srcdir=`pwd`
+cd $testdir/
+
+# title
+echo >> $testdir/results.log
+echo "test: $var" >> $testdir/results.log
+echo >> $testdir/results.log
+echo "directory: `pwd`" >> $testdir/results.log
+
+# needs the archive and the installed module
+if [ ! -e ./lib/libgf3d.a ]; then
+  echo "skipped: no HDF5 build of libgf3d (see 5.configure.hdf5_make.sh)" >> $testdir/results.log
+  echo "skipped: no HDF5 build of libgf3d"
+  exit 0
+fi
+if [ ! -e ./include/gf3d.mod ] && [ ! -e ./include/GF3D.mod ]; then
+  echo "skipped: the public module is not installed in include/" >> $testdir/results.log
+  echo "skipped: no include/gf3d.mod"
+  exit 0
+fi
+
+# locates an example database with a validation source
+EX=""
+for cand in "${GF3D_TEST_EXAMPLE}" \
+            "$srcdir/EXAMPLES/green_function_database/regional" \
+            "$srcdir/EXAMPLES/green_function_database/global"; do
+  [ -z "$cand" ] && continue
+  if [ -e "$cand/GFDB/mesh_info.h5" ] && [ -e "$cand/validation_data/CMTSOLUTION" ]; then
+    EX="$cand"; break
+  fi
+done
+
+if [ -z "$EX" ]; then
+  echo "skipped: no built example database (set GF3D_TEST_EXAMPLE)" >> $testdir/results.log
+  echo "skipped: no built example database"
+  exit 0
+fi
+
+GFDB="$EX/GFDB"
+CMT="$EX/validation_data/CMTSOLUTION"
+FORCE="$EX/validation_data/FORCESOLUTION"
+[ -e "$FORCE" ] || FORCE=""
+echo "example: $EX" >> $testdir/results.log
+
+# clean
+mkdir -p bin
+rm -f ./bin/$var
+
+# single compilation
+echo "compilation: $var" >> $testdir/results.log
+make -f $var.makefile $var >> $testdir/results.log 2>&1
+echo "" >> $testdir/results.log
+
+# check
+if [ ! -e ./bin/$var ]; then
+  echo "compilation of $var failed, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+# runs test
+echo "run: `date`" >> $testdir/results.log
+./bin/$var "$GFDB" "$CMT" $FORCE >> $testdir/results.log 2>$testdir/error.log
+
+# checks exit code
+if [[ $? -ne 0 ]]; then
+  echo "test failed"; echo "error log:"; cat $testdir/error.log; echo ""
+  echo "results:"; tail -n 30 $testdir/results.log
+  exit 1
+fi
+
+# checks error output (note: fortran stop returns with a zero-exit code)
+if [[ -s $testdir/error.log ]]; then
+  echo "returned ERROR output:" >> $testdir/results.log
+  cat $testdir/error.log >> $testdir/results.log
+  exit 1
+fi
+rm -f $testdir/error.log
+
+#cleanup
+rm -f ./bin/$var
+rm -f *.mod
+# done
+echo "successfully tested: `date`" >> $testdir/results.log

--- a/tests/gf3d/9f.test_gf_python.sh
+++ b/tests/gf3d/9f.test_gf_python.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+###################################################
+#
+# Runs test_gf_python: the ctypes package against xgf3d's own output.
+#
+# Needs the shared library from 5.configure.hdf5_make.sh, a built example
+# database, and a Python with numpy. All three are absent in CI and on a
+# fresh checkout, so all three are skips rather than failures.
+#
+# Note the Python step is judged by its exit code alone, not by whether it
+# wrote to stderr: numpy and obspy warn there routinely, and the test itself
+# provokes a RuntimeWarning or two on purpose. The compile-time checks in
+# the other runners keep the stricter rule.
+#
+###################################################
+
+testdir=`pwd`
+
+# executable
+var=test_gf_python
+
+#checks if ROOT valid
+if [ -z "${ROOT}" ]; then export ROOT=../../ ; fi
+cd $ROOT/
+srcdir=`pwd`
+cd $testdir/
+
+# title
+echo >> $testdir/results.log
+echo "test: $var" >> $testdir/results.log
+echo >> $testdir/results.log
+echo "directory: `pwd`" >> $testdir/results.log
+
+# needs the shared library and the executable to compare against
+if [ ! -e ./lib/libgf3d.so ]; then
+  echo "skipped: no shared build of libgf3d (see 5.configure.hdf5_make.sh)" >> $testdir/results.log
+  echo "skipped: no shared build of libgf3d"
+  exit 0
+fi
+if [ ! -e ./bin/xgf3d ]; then
+  echo "skipped: no xgf3d to compare against" >> $testdir/results.log
+  echo "skipped: no xgf3d"
+  exit 0
+fi
+
+# a Python with numpy. GF3D_PYTHON wins; otherwise the examples' own venv,
+# then whatever is on PATH.
+PY="${GF3D_PYTHON}"
+if [ -z "$PY" ]; then PY="$srcdir/EXAMPLES/green_function_database/.venv/bin/python"; fi
+if ! "$PY" -c "import numpy" > /dev/null 2>&1; then
+  PY=`command -v python3`
+fi
+if [ -z "$PY" ] || ! "$PY" -c "import numpy" > /dev/null 2>&1; then
+  echo "skipped: no Python with numpy (set GF3D_PYTHON)" >> $testdir/results.log
+  echo "skipped: no Python with numpy"
+  exit 0
+fi
+echo "python: $PY" >> $testdir/results.log
+
+# locates an example database with a validation source
+EX=""
+for cand in "${GF3D_TEST_EXAMPLE}" \
+            "$srcdir/EXAMPLES/green_function_database/regional" \
+            "$srcdir/EXAMPLES/green_function_database/global"; do
+  [ -z "$cand" ] && continue
+  if [ -e "$cand/GFDB/mesh_info.h5" ] && [ -e "$cand/validation_data/CMTSOLUTION" ]; then
+    EX="$cand"; break
+  fi
+done
+
+if [ -z "$EX" ]; then
+  echo "skipped: no built example database (set GF3D_TEST_EXAMPLE)" >> $testdir/results.log
+  echo "skipped: no built example database"
+  exit 0
+fi
+
+GFDB="$EX/GFDB"
+CMT="$EX/validation_data/CMTSOLUTION"
+FORCE="$EX/validation_data/FORCESOLUTION"
+[ -e "$FORCE" ] || FORCE=""
+
+# a second, different database exercises the shared-parameter refresh
+GFDB2=""
+for cand in "$srcdir/EXAMPLES/green_function_database/regional" \
+            "$srcdir/EXAMPLES/green_function_database/global"; do
+  if [ "$cand/GFDB" != "$GFDB" ] && [ -e "$cand/GFDB/mesh_info.h5" ]; then
+    GFDB2="$cand/GFDB"; break
+  fi
+done
+
+echo "example: $EX" >> $testdir/results.log
+[ -n "$GFDB2" ] && echo "second database: $GFDB2" >> $testdir/results.log
+
+# runs test
+echo "run: `date`" >> $testdir/results.log
+PYTHONPATH="$srcdir/utils/green_function" \
+GF3D_LIB="$testdir/lib/libgf3d.so" \
+  "$PY" "$testdir/$var.py" "$testdir/bin/xgf3d" "$GFDB" "$CMT" "$FORCE" "$GFDB2" \
+  >> $testdir/results.log 2>$testdir/error.log
+
+# checks exit code
+if [[ $? -ne 0 ]]; then
+  echo "test failed"; echo "error log:"; cat $testdir/error.log; echo ""
+  echo "results:"; tail -n 40 $testdir/results.log
+  exit 1
+fi
+
+# stderr is recorded but does not fail the test: see the note at the top
+if [[ -s $testdir/error.log ]]; then
+  echo "stderr (not a failure):" >> $testdir/results.log
+  cat $testdir/error.log >> $testdir/results.log
+fi
+rm -f $testdir/error.log
+
+#cleanup
+rm -rf $srcdir/utils/green_function/gf3d/__pycache__
+# done
+echo "successfully tested: `date`" >> $testdir/results.log

--- a/tests/gf3d/test_gf3d_ext.f90
+++ b/tests/gf3d/test_gf3d_ext.f90
@@ -1,0 +1,575 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- test_gf3d_ext -- the external program's view of the library
+!----
+!---- This is the "downstream caller" test: it is compiled with -I./include
+!---- and linked against ./lib/libgf3d.a and nothing else -- no ./obj, no
+!---- gf_* module files -- so it can only see what an installed library
+!---- offers. If `use gf3d` does not by itself name everything a caller
+!---- needs, this test does not compile, which is the point.
+!----
+!---- It also reaches the C entry points, and it does so the way a foreign
+!---- caller would: by transcribing include/gf3d.h into its own interface
+!---- blocks and bind(C) types. gf3d_capi.mod is deliberately not installed,
+!---- so this is not a shortcut but the real exercise -- and it means the
+!---- header and the Fortran facade are checked against a third, independent
+!---- transcription of the same layout.
+!----
+!---- What it asserts: the two routes to the same numbers agree. The file
+!---- route reads the CMTSOLUTION through the solver's own reader and calls
+!---- the public Fortran API; the C route passes the same values through the
+!---- ABI. Seismograms and all ten partials must match to 1e-12 relative --
+!---- a derived tolerance, not equality, because the two paths are separate
+!---- compilation units evaluating the same expressions (testing.md).
+!----
+!---- Usage: test_gf3d_ext <GFDB directory> <CMTSOLUTION> [FORCESOLUTION]
+!----
+
+  program test_gf3d_ext
+
+! everything below comes from this one module: that is the claim being tested
+  use gf3d
+
+  use, intrinsic :: iso_c_binding, only: c_int,c_double,c_char,c_ptr,c_null_char,c_null_ptr
+
+  implicit none
+
+  !--- the C ABI, transcribed from include/gf3d.h ---
+
+  integer, parameter :: NCOMP_C = 3
+
+  type, bind(C) :: gf3d_source_t
+    integer(c_int) :: source_type
+    integer(c_int) :: force_stf
+    real(c_double) :: latitude
+    real(c_double) :: longitude
+    real(c_double) :: depth_km
+    real(c_double) :: hdur
+    real(c_double) :: time_shift
+    real(c_double), dimension(6) :: moment
+    real(c_double) :: force_factor
+    real(c_double), dimension(3) :: force_dir
+  end type gf3d_source_t
+
+  type, bind(C) :: gf3d_plan_t
+    integer(c_int) :: nt,nt_db,npad,subsample_step,khalf,guard,kind_stf,pad_
+    real(c_double) :: dt,dt_sub,t0_db,t0_req,t0,t_first
+    real(c_double) :: hdur_src,hdur_target,hdur_db,hdur_corr,trunc
+  end type gf3d_plan_t
+
+  type, bind(C) :: gf3d_info_t
+    integer(c_int) :: nelem,nstations,nstep,nt_subsampled,subsample_step
+    integer(c_int) :: ngllx,nglly,ngllz
+    integer(c_int) :: topography,ellipticity,rotation,attenuation,gravity,pad_
+    real(c_double) :: dt,t0,r_planet,rhoav,scale_displ
+  end type gf3d_info_t
+
+  interface
+
+    integer(c_int) function c_gf3d_open(path,check_completion,h) bind(C,name='gf3d_open')
+      import :: c_int,c_char
+      character(kind=c_char), dimension(*), intent(in) :: path
+      integer(c_int), value :: check_completion
+      integer(c_int), intent(out) :: h
+    end function c_gf3d_open
+
+    integer(c_int) function c_gf3d_close(h) bind(C,name='gf3d_close')
+      import :: c_int
+      integer(c_int), value :: h
+    end function c_gf3d_close
+
+    integer(c_int) function c_gf3d_get_info(h,info) bind(C,name='gf3d_get_info')
+      import :: c_int,gf3d_info_t
+      integer(c_int), value :: h
+      type(gf3d_info_t), intent(out) :: info
+    end function c_gf3d_get_info
+
+    integer(c_int) function c_gf3d_get_plan(h,src,t0_req,plan) bind(C,name='gf3d_get_plan')
+      import :: c_int,c_double,gf3d_source_t,gf3d_plan_t
+      integer(c_int), value :: h
+      type(gf3d_source_t), intent(in) :: src
+      real(c_double), value :: t0_req
+      type(gf3d_plan_t), intent(out) :: plan
+    end function c_gf3d_get_plan
+
+    integer(c_int) function c_gf3d_seismograms(h,src,t0_req,nt,seis,t,onset,loc) &
+      bind(C,name='gf3d_seismograms')
+      import :: c_int,c_double,c_ptr,gf3d_source_t
+      integer(c_int), value :: h
+      type(gf3d_source_t), intent(in) :: src
+      real(c_double), value :: t0_req
+      integer(c_int), value :: nt
+      real(c_double), dimension(*), intent(out) :: seis,t,onset
+      type(c_ptr), value :: loc
+    end function c_gf3d_seismograms
+
+    integer(c_int) function c_gf3d_partials(h,src,t0_req,itypsokern,nt,ndp, &
+                                            seis,dp,t,onset,loc) bind(C,name='gf3d_partials')
+      import :: c_int,c_double,c_ptr,gf3d_source_t
+      integer(c_int), value :: h
+      type(gf3d_source_t), intent(in) :: src
+      real(c_double), value :: t0_req
+      integer(c_int), value :: itypsokern,nt,ndp
+      real(c_double), dimension(*), intent(out) :: seis,dp,t,onset
+      type(c_ptr), value :: loc
+    end function c_gf3d_partials
+
+  end interface
+
+  !--- the test ---
+
+  double precision, parameter :: TOL = 1.d-12
+
+  type(t_gfdb) :: db
+  type(t_gf_source) :: src
+  double precision, dimension(:,:,:), allocatable :: synt
+  double precision, dimension(:,:,:,:), allocatable :: dp
+  double precision, dimension(:), allocatable :: t
+
+  type(gf3d_source_t) :: csrc
+  type(gf3d_plan_t) :: cplan
+  type(gf3d_info_t) :: cinfo
+  real(c_double), dimension(:), allocatable :: cseis,cdp,ct,consetd
+  integer(c_int) :: ch,cerr
+
+  character(len=512) :: dbpath,cmtpath,forcepath
+  integer :: ierr,nfail,narg
+
+  nfail = 0
+
+  write(*,*)
+  write(*,*) '******************************'
+  write(*,*) 'test_gf3d_ext'
+  write(*,*) '******************************'
+  write(*,*)
+
+  narg = command_argument_count()
+  if (narg < 2) then
+    write(*,*) 'usage: test_gf3d_ext <GFDB> <CMTSOLUTION> [FORCESOLUTION]'
+    stop 1
+  endif
+  call get_command_argument(1,dbpath)
+  call get_command_argument(2,cmtpath)
+  forcepath = ''
+  if (narg >= 3) call get_command_argument(3,forcepath)
+
+  !--- the Fortran route ---
+
+  write(*,*) '1. the public Fortran module'
+
+  call gf_open(trim(dbpath),db,ierr)
+  call report_true('   gf_open',ierr == GF_OK,nfail)
+  if (ierr /= GF_OK) then
+    write(*,*) '   ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  call gf_read_cmt_source(trim(cmtpath),db%dt,src,ierr)
+  call report_true('   gf_read_cmt_source',ierr == GF_OK,nfail)
+  if (ierr /= GF_OK) stop 1
+
+  call get_seismograms(db,src,synt,dp,2,t,ierr)
+  call report_true('   get_seismograms with partials',ierr == GF_OK,nfail)
+  if (ierr /= GF_OK) then
+    write(*,*) '   ',trim(gf_errmsg)
+    stop 1
+  endif
+
+  call report_true('   synt is (nsta,3,nt)', &
+    size(synt,1) == db%nstations .and. size(synt,2) == GF_NCOMP .and. &
+    size(synt,3) == size(t),nfail)
+  call report_true('   dp is (10,nsta,3,nt)', &
+    size(dp,1) == GF_NDP_LOC .and. size(dp,2) == db%nstations,nfail)
+  call report_true('   the partial names are the GF3DF order', &
+    GF_DP_NAME(1) == 'Mrr' .and. GF_DP_NAME(GF_DP_TIM) == 'tim',nfail)
+
+  write(*,'(a,i0,a,i0,a)') '       ',db%nstations,' stations, ',size(t),' samples'
+
+  !--- the same thing through the C ABI ---
+
+  write(*,*) '2. the same source through the C entry points'
+
+  cerr = c_gf3d_open(trim(dbpath)//c_null_char,0_c_int,ch)
+  call report_true('   gf3d_open',cerr == GF_OK,nfail)
+  if (cerr /= GF_OK) stop 1
+
+  cerr = c_gf3d_get_info(ch,cinfo)
+  call report_true('   gf3d_get_info agrees with the handle', &
+    cerr == GF_OK .and. int(cinfo%nstations) == db%nstations .and. &
+    int(cinfo%nelem) == db%nelem,nfail)
+
+  ! the values a caller would have parsed out of the CMTSOLUTION, recovered
+  ! from what the reader produced: the moment tensor is stored
+  ! non-dimensional, so scale_moment puts it back into dyne-cm, and the
+  ! original time shift is in min_tshift_src_original
+  csrc%source_type = GF_SRC_CMT
+  csrc%force_stf = 0
+  csrc%latitude = src%latitude
+  csrc%longitude = src%longitude
+  csrc%depth_km = src%depth
+  csrc%hdur = src%hdur
+  csrc%time_shift = src%min_tshift_src_original
+  csrc%moment(1:6) = src%moment_tensor(1:6)*src%scale_moment
+  csrc%force_factor = 0.d0
+  csrc%force_dir(1:3) = 0.d0
+
+  cerr = c_gf3d_get_plan(ch,csrc,-1.0_c_double,cplan)
+  call report_true('   gf3d_get_plan',cerr == GF_OK,nfail)
+  call report_true('   the plan lengths agree',int(cplan%nt) == size(t),nfail)
+  if (cerr /= GF_OK) stop 1
+
+  allocate(cseis(db%nstations*GF_NCOMP*int(cplan%nt)), &
+           cdp(db%nstations*GF_NDP_LOC*GF_NCOMP*int(cplan%nt)), &
+           ct(int(cplan%nt)),consetd(db%nstations))
+
+  cerr = c_gf3d_partials(ch,csrc,-1.0_c_double,2_c_int,cplan%nt, &
+                         int(GF_NDP_LOC,kind=c_int),cseis,cdp,ct,consetd,c_null_ptr)
+  call report_true('   gf3d_partials',cerr == GF_OK,nfail)
+  if (cerr /= GF_OK) stop 1
+
+  !--- and they must be the same numbers ---
+
+  write(*,*) '3. the two routes against each other'
+
+  call compare_seis(db%nstations,int(cplan%nt),synt,cseis,nfail)
+  call compare_time(int(cplan%nt),t,ct,nfail)
+  call compare_dp(db%nstations,int(cplan%nt),dp,cdp,nfail)
+
+  deallocate(cseis,cdp,ct,consetd)
+  deallocate(synt,dp,t)
+
+  !--- a force source, if the example ships one ---
+
+  if (len_trim(forcepath) > 0) then
+    write(*,*) '4. a force source, both routes'
+    call test_force(db,ch,forcepath,nfail)
+  endif
+
+  cerr = c_gf3d_close(ch)
+  call report_true('   gf3d_close',cerr == GF_OK,nfail)
+
+  ! the pair a long-lived caller must use: gf_close alone leaves the
+  ! kd-tree allocated
+  call gf_release(db)
+  call report_true('   gf_release',.not. db%is_open,nfail)
+
+  write(*,*)
+  if (nfail == 0) then
+    write(*,*) 'test_gf3d_ext: all assertions passed'
+  else
+    write(*,*) 'test_gf3d_ext: ',nfail,' assertion(s) FAILED'
+    stop 1
+  endif
+  write(*,*)
+
+  contains
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine report_true(name,cond,nfail)
+
+  implicit none
+
+  character(len=*), intent(in) :: name
+  logical, intent(in) :: cond
+  integer, intent(inout) :: nfail
+
+  if (cond) then
+    write(*,'(a,a)') '  ok   ',name
+  else
+    write(*,'(a,a)') '  FAIL ',name
+    nfail = nfail + 1
+  endif
+
+  end subroutine report_true
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine report(name,err,tol,nfail)
+
+  implicit none
+
+  character(len=*), intent(in) :: name
+  double precision, intent(in) :: err,tol
+  integer, intent(inout) :: nfail
+
+  if (err <= tol) then
+    write(*,'(a,a,a,es12.5,a,es12.5,a)') '  ok   ',name,'   error = ',err,'  (tol ',tol,')'
+  else
+    write(*,'(a,a,a,es12.5,a,es12.5,a)') '  FAIL ',name,'   error = ',err,'  (tol ',tol,')'
+    nfail = nfail + 1
+  endif
+
+  end subroutine report
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine compare_seis(nsta,nt,synt,cseis,nfail)
+
+! the Fortran (nsta,3,nt) against the C [ista][icomp][it]
+
+  implicit none
+
+  integer, intent(in) :: nsta,nt
+  double precision, dimension(nsta,GF_NCOMP,nt), intent(in) :: synt
+  real(c_double), dimension(nt,GF_NCOMP,nsta), intent(in) :: cseis
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  integer :: ista,icomp,it
+  double precision :: worst,peak
+
+  worst = 0.d0
+  peak = 0.d0
+  do ista = 1,nsta
+    do icomp = 1,GF_NCOMP
+      do it = 1,nt
+        peak = max(peak,abs(synt(ista,icomp,it)))
+        worst = max(worst,abs(synt(ista,icomp,it) - cseis(it,icomp,ista)))
+      enddo
+    enddo
+  enddo
+
+  call report('   seismograms   ',worst/max(peak,1.d-300),TOL,nfail)
+
+  end subroutine compare_seis
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine compare_time(nt,t,ct,nfail)
+
+  implicit none
+
+  integer, intent(in) :: nt
+  double precision, dimension(nt), intent(in) :: t
+  real(c_double), dimension(nt), intent(in) :: ct
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  integer :: it
+  double precision :: worst
+
+  worst = 0.d0
+  do it = 1,nt
+    worst = max(worst,abs(t(it) - ct(it)))
+  enddo
+
+  call report('   time axis     ',worst,1.d-12,nfail)
+
+  end subroutine compare_time
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine compare_dp(nsta,nt,dp,cdp,nfail)
+
+! the Fortran (ndp,nsta,3,nt) against the C [ista][ip][icomp][it]
+!
+! Reported per partial, because the ten of them carry four different units
+! and a mistake in the packing would show in one slot, not all ten.
+
+  implicit none
+
+  integer, intent(in) :: nsta,nt
+  double precision, dimension(GF_NDP_LOC,nsta,GF_NCOMP,nt), intent(in) :: dp
+  real(c_double), dimension(nt,GF_NCOMP,GF_NDP_LOC,nsta), intent(in) :: cdp
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  integer :: ista,icomp,it,ip
+  double precision :: worst,peak
+  character(len=18) :: label
+
+  do ip = 1,GF_NDP_LOC
+    worst = 0.d0
+    peak = 0.d0
+    do ista = 1,nsta
+      do icomp = 1,GF_NCOMP
+        do it = 1,nt
+          peak = max(peak,abs(dp(ip,ista,icomp,it)))
+          worst = max(worst,abs(dp(ip,ista,icomp,it) - cdp(it,icomp,ip,ista)))
+        enddo
+      enddo
+    enddo
+    write(label,'(a,a,a)') '   dp ',GF_DP_NAME(ip),'        '
+    call report(label,worst/max(peak,1.d-300),TOL,nfail)
+  enddo
+
+  end subroutine compare_dp
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine test_force(db,ch,forcepath,nfail)
+
+! the force path, both routes, seismograms only
+
+  implicit none
+
+  type(t_gfdb), intent(inout) :: db
+  integer(c_int), intent(in) :: ch
+  character(len=*), intent(in) :: forcepath
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gf_source) :: fsrc
+  double precision, dimension(:,:,:), allocatable :: fsynt
+  double precision, dimension(:,:,:,:), allocatable :: fdp
+  double precision, dimension(:), allocatable :: ft
+  type(gf3d_source_t) :: cf
+  type(gf3d_plan_t) :: fplan
+  real(c_double), dimension(:), allocatable :: fseis,fct,fonset
+  integer(c_int) :: cerr
+  integer :: ierr
+
+  call gf_read_force_source(trim(forcepath),db%dt,fsrc,ierr)
+  call report_true('   gf_read_force_source',ierr == GF_OK,nfail)
+  if (ierr /= GF_OK) return
+
+  call get_seismograms(db,fsrc,fsynt,fdp,0,ft,ierr)
+  call report_true('   get_seismograms, force',ierr == GF_OK,nfail)
+  if (ierr /= GF_OK) return
+
+  ! The C side takes the file's own numbers, in the file's own units, so
+  ! they are read from the file rather than recovered from the reader's
+  ! output: factor_force_source comes back already divided by scaleF, and
+  ! an external caller has no way to name that constant.
+  cf%source_type = GF_SRC_FORCE
+  cf%moment(1:6) = 0.d0
+  call read_forcesolution(forcepath,cf,ierr)
+  call report_true('   FORCESOLUTION parsed',ierr == 0,nfail)
+  if (ierr /= 0) return
+
+  cerr = c_gf3d_get_plan(ch,cf,-1.0_c_double,fplan)
+  call report_true('   gf3d_get_plan, force',cerr == GF_OK,nfail)
+  if (cerr /= GF_OK) return
+
+  call report_true('   the force plan lengths agree',int(fplan%nt) == size(ft),nfail)
+
+  allocate(fseis(db%nstations*GF_NCOMP*int(fplan%nt)),fct(int(fplan%nt)), &
+           fonset(db%nstations))
+
+  cerr = c_gf3d_seismograms(ch,cf,-1.0_c_double,fplan%nt,fseis,fct,fonset,c_null_ptr)
+  call report_true('   gf3d_seismograms, force',cerr == GF_OK,nfail)
+
+  if (cerr == GF_OK) call compare_seis(db%nstations,int(fplan%nt),fsynt,fseis,nfail)
+
+  deallocate(fseis,fct,fonset)
+  deallocate(fsynt,fdp,ft)
+
+  end subroutine test_force
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine read_forcesolution(filename,cf,ierr)
+
+! the eleven lines of a FORCESOLUTION, in the file's own units
+!
+! Every line is "name: value", so the value is what follows the last colon;
+! list-directed input accepts the Fortran `d` exponent the factor is
+! usually written with. This is what a caller outside the tree has to do,
+! and it is the reason the C API takes values rather than a path: reading
+! the file with get_force() would put its stop statements back in reach.
+
+  implicit none
+
+  character(len=*), intent(in) :: filename
+  type(gf3d_source_t), intent(inout) :: cf
+  integer, intent(out) :: ierr
+
+  ! local parameters
+  integer, parameter :: IIN_F = 93
+  character(len=512) :: line
+  integer :: iline,icolon,ios,istf
+  double precision :: v
+
+  ierr = 1
+
+  open(unit=IIN_F,file=trim(filename),status='old',action='read',iostat=ios)
+  if (ios /= 0) return
+
+  do iline = 1,11
+    read(IIN_F,'(a)',iostat=ios) line
+    if (ios /= 0) then
+      close(IIN_F)
+      return
+    endif
+
+    ! the first line is 'FORCE <label>', which carries no value
+    if (iline == 1) cycle
+
+    icolon = index(line,':',back=.true.)
+    if (icolon < 1) then
+      close(IIN_F)
+      return
+    endif
+
+    if (iline == 7) then
+      read(line(icolon+1:),*,iostat=ios) istf
+    else
+      read(line(icolon+1:),*,iostat=ios) v
+    endif
+    if (ios /= 0) then
+      close(IIN_F)
+      return
+    endif
+
+    select case (iline)
+    case (2) ; cf%time_shift = v
+    case (3) ; cf%hdur = v
+    case (4) ; cf%latitude = v
+    case (5) ; cf%longitude = v
+    case (6) ; cf%depth_km = v
+    case (7) ; cf%force_stf = int(istf,kind=c_int)
+    case (8) ; cf%force_factor = v
+    case (9) ; cf%force_dir(1) = v
+    case (10) ; cf%force_dir(2) = v
+    case (11) ; cf%force_dir(3) = v
+    end select
+  enddo
+
+  close(IIN_F)
+
+  ierr = 0
+
+  end subroutine read_forcesolution
+
+  end program test_gf3d_ext

--- a/tests/gf3d/test_gf3d_ext.makefile
+++ b/tests/gf3d/test_gf3d_ext.makefile
@@ -1,0 +1,21 @@
+# includes default Makefile from previous configuration
+include Makefile
+
+# test target
+default: test_gf3d_ext
+
+## compilation directories
+L := ./lib
+I := ./include
+
+# The downstream caller's view, and deliberately nothing more: -I./include
+# for gf3d.mod, ./lib/libgf3d.a for the code. No -I./obj, no gf_*.o, no
+# gf_manufactured -- if `use gf3d` does not name everything the program
+# needs, this does not compile, which is the assertion.
+#
+# The static library here, where test_gf_capi links the shared one, so that
+# both artefacts of `make gf3d` are exercised. $(LDFLAGS) supplies HDF5, as
+# it does for xgf3d itself; serial link, no $(MPILIBS).
+test_gf3d_ext:
+	${FCCOMPILE_CHECK} -I$I -o ./bin/test_gf3d_ext \
+		test_gf3d_ext.f90 $L/libgf3d.a $(LDFLAGS)

--- a/tests/gf3d/test_gf_capi.c
+++ b/tests/gf3d/test_gf_capi.c
@@ -1,0 +1,484 @@
+/*
+ *=====================================================================
+ *
+ *                       S p e c f e m 3 D  G l o b e
+ *                       ----------------------------
+ *
+ *     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+ *                        Princeton University, USA
+ *                and CNRS / University of Marseille, France
+ *                 (there are currently many more authors!)
+ * (c) Princeton University and CNRS / University of Marseille, April 2014
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *=====================================================================
+ */
+
+/*
+ * test_gf_capi -- the C round trip, and that no path can stop
+ *
+ * Tier 2: needs the HDF5 build of the library and one of the example
+ * databases; skips cleanly without them (see 9d.test_gf_capi.sh).
+ *
+ * This is the first test in the tree written in C, because it is the first
+ * thing in the tree with a C ABI. It exists to check two different claims.
+ *
+ * The first is that the ABI is right: that a caller who has only
+ * include/gf3d.h and lib/libgf3d.so can open a database, ask what is in it,
+ * locate a source, and get seismograms and partials whose shape, order and
+ * units are what the header says. The oracle for the numbers is an identity
+ * rather than a reference file: summing the moment-tensor partials against
+ * the CMTSOLUTION's own components must reproduce the seismogram, exactly
+ * as it does in the Fortran tests, and that cannot come out right by
+ * accident if an index is transposed.
+ *
+ * The second is that nothing here can end the process. Every deliberate
+ * mistake below -- a missing database, a bad handle, a closed handle, a
+ * wrong array length, a NaN, partials of a force source -- has to come back
+ * as an error code with the program still running. That is the property
+ * that lets this library be loaded into a Python interpreter, and the only
+ * way to test it is to try each one and still reach the end.
+ *
+ * Usage: test_gf_capi <GFDB directory> <CMTSOLUTION>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "gf3d.h"
+
+static int nfail = 0;
+
+static void ok(const char *name, int cond)
+{
+  if (cond) {
+    printf("  ok   %s\n", name);
+  } else {
+    printf("  FAIL %s\n", name);
+    nfail++;
+  }
+}
+
+static void ok_err(const char *name, double err, double tol)
+{
+  if (err <= tol && !isnan(err)) {
+    printf("  ok   %-38s error = %12.5e  (tol %12.5e)\n", name, err, tol);
+  } else {
+    printf("  FAIL %-38s error = %12.5e  (tol %12.5e)\n", name, err, tol);
+    nfail++;
+  }
+}
+
+/* the status code a call must return, reported with its message */
+static void ok_status(const char *name, int got, int want)
+{
+  char msg[512], nm[64];
+  gf3d_error_string(got, nm, (int)sizeof(nm));
+  gf3d_last_error(msg, (int)sizeof(msg));
+  if (got == want) {
+    printf("  ok   %-38s -> %s\n", name, nm);
+  } else {
+    printf("  FAIL %-38s -> %s (wanted %d), %s\n", name, nm, want, msg);
+    nfail++;
+  }
+}
+
+/*
+ * The CMTSOLUTION, parsed here in C.
+ *
+ * Deliberate: the C API takes numbers, never a path, precisely so that no
+ * caller reaches get_cmt()'s stop statements. Parsing is the caller's job,
+ * and this is what that costs -- about twenty lines. Every line of the
+ * format is "name: value", so the value is what follows the last colon.
+ */
+static int read_cmtsolution(const char *path, gf3d_source *src)
+{
+  FILE *f = fopen(path, "r");
+  char line[512];
+  int iline = 0;
+
+  if (f == NULL) return 1;
+
+  memset(src, 0, sizeof(*src));
+  src->source_type = GF_SRC_CMT;
+
+  while (fgets(line, (int)sizeof(line), f) != NULL) {
+    char *colon = strrchr(line, ':');
+    double v = 0.0;
+    if (iline > 0) {
+      if (colon == NULL) { fclose(f); return 2; }
+      v = atof(colon + 1);
+    }
+    switch (iline) {
+      case 2:  src->time_shift = v; break;
+      case 3:  src->hdur       = v; break;
+      case 4:  src->latitude   = v; break;
+      case 5:  src->longitude  = v; break;
+      case 6:  src->depth_km   = v; break;
+      case 7:  src->moment[0]  = v; break;
+      case 8:  src->moment[1]  = v; break;
+      case 9:  src->moment[2]  = v; break;
+      case 10: src->moment[3]  = v; break;
+      case 11: src->moment[4]  = v; break;
+      case 12: src->moment[5]  = v; break;
+      default: break;
+    }
+    iline++;
+  }
+  fclose(f);
+
+  return (iline >= 13) ? 0 : 3;
+}
+
+int main(int argc, char **argv)
+{
+  const char *dbpath, *cmtpath;
+  gf3d_handle h = 0, h2 = 0;
+  gf3d_info info;
+  gf3d_station sta;
+  gf3d_location loc;
+  gf3d_plan plan;
+  gf3d_source src, force;
+  char buf[128], name[16], unit[16];
+  double *seis = NULL, *dp = NULL, *t = NULL, *onset = NULL;
+  int ierr, ndp, i, j, k, ip, nsta, nt;
+  int sz_source, sz_info, sz_station, sz_location, sz_plan;
+
+  if (argc < 3) {
+    fprintf(stderr, "usage: %s <GFDB> <CMTSOLUTION>\n", argv[0]);
+    return 1;
+  }
+  dbpath = argv[1];
+  cmtpath = argv[2];
+
+  printf("\n ******************************\n");
+  printf(" test_gf_capi\n");
+  printf(" ******************************\n\n");
+
+  /* ---------------------------------------------------------------- */
+  printf(" 1. version, sizes and error strings\n");
+
+  ierr = gf3d_version(buf, (int)sizeof(buf));
+  ok("gf3d_version returns GF_OK", ierr == GF_OK);
+  ok("version string is not empty", strlen(buf) > 0);
+  printf("       library version: %s\n", buf);
+
+  /*
+   * The struct sizes: this header is transcribed by hand into Fortran
+   * bind(C) types and again into Python ctypes.Structures, so the one thing
+   * that can silently go wrong is a layout drift. Ask the library.
+   */
+  ierr = gf3d_sizeof(&sz_source, &sz_info, &sz_station, &sz_location, &sz_plan);
+  ok("gf3d_sizeof returns GF_OK", ierr == GF_OK);
+  ok("sizeof(gf3d_source) agrees", sz_source == (int)sizeof(gf3d_source));
+  ok("sizeof(gf3d_info) agrees", sz_info == (int)sizeof(gf3d_info));
+  ok("sizeof(gf3d_station) agrees", sz_station == (int)sizeof(gf3d_station));
+  ok("sizeof(gf3d_location) agrees", sz_location == (int)sizeof(gf3d_location));
+  ok("sizeof(gf3d_plan) agrees", sz_plan == (int)sizeof(gf3d_plan));
+
+  /* NULL is allowed for every one of them */
+  ierr = gf3d_sizeof(NULL, NULL, NULL, NULL, NULL);
+  ok("gf3d_sizeof accepts NULL throughout", ierr == GF_OK);
+
+  gf3d_error_string(GF_ERR_NO_ELEMENT, buf, (int)sizeof(buf));
+  ok("error string for GF_ERR_NO_ELEMENT", strlen(buf) > 0);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 2. a database that is not there\n");
+
+  ierr = gf3d_open("/nonexistent/gf3d/database", 0, &h);
+  ok_status("opening a missing database", ierr, GF_ERR_NO_PATH);
+  ok("no handle was handed out", h == 0);
+  gf3d_last_error(buf, (int)sizeof(buf));
+  ok("a message was left behind", strlen(buf) > 0);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 3. opening the example database\n");
+
+  ierr = gf3d_open(dbpath, 0, &h);
+  ok_status("gf3d_open", ierr, GF_OK);
+  if (ierr != GF_OK) return 1;
+  ok("handle is in range", h >= 1 && h <= GF3D_MAX_HANDLES);
+
+  ierr = gf3d_get_info(h, &info);
+  ok_status("gf3d_get_info", ierr, GF_OK);
+  printf("       %d elements, %d stations, %d samples at dt = %g x %d\n",
+         info.nelem, info.nstations, info.nt_subsampled, info.dt,
+         info.subsample_step);
+  ok("at least one element", info.nelem > 0);
+  ok("at least one station", info.nstations > 0);
+  ok("dt is positive", info.dt > 0.0);
+  ok("subsample_step is positive", info.subsample_step > 0);
+  ok("r_planet is a planet", info.r_planet > 1.0e6);
+  ok("rhoav is a density", info.rhoav > 100.0);
+
+  nsta = info.nstations;
+
+  /* station names must be present and distinct */
+  {
+    int distinct = 1, nonempty = 1;
+    char ids[64][GF3D_STRLEN];
+    for (i = 0; i < nsta && i < 64; i++) {
+      ierr = gf3d_get_station(h, i, &sta);
+      if (ierr != GF_OK) { nonempty = 0; break; }
+      strncpy(ids[i], sta.id, GF3D_STRLEN - 1);
+      ids[i][GF3D_STRLEN - 1] = '\0';
+      if (strlen(ids[i]) == 0) nonempty = 0;
+      for (j = 0; j < i; j++) if (strcmp(ids[i], ids[j]) == 0) distinct = 0;
+    }
+    ok("every station has a name", nonempty);
+    ok("station names are distinct", distinct);
+    printf("       first station: %s at %.4f, %.4f\n", ids[0],
+           sta.latitude, sta.longitude);
+  }
+
+  ok_status("station index -1 refused", gf3d_get_station(h, -1, &sta), GF_ERR_ARG);
+  ok_status("station index nsta refused", gf3d_get_station(h, nsta, &sta), GF_ERR_ARG);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 4. the partial derivative table\n");
+
+  ierr = gf3d_ndp(0, &ndp);
+  ok("gf3d_ndp(0) = 0", ierr == GF_OK && ndp == 0);
+  ierr = gf3d_ndp(1, &ndp);
+  ok("gf3d_ndp(1) = 6", ierr == GF_OK && ndp == GF_NDP_MT);
+  ierr = gf3d_ndp(2, &ndp);
+  ok("gf3d_ndp(2) = 10", ierr == GF_OK && ndp == GF_NDP_LOC);
+  ok_status("gf3d_ndp(3) refused", gf3d_ndp(3, &ndp), GF_ERR_ARG);
+
+  ierr = gf3d_partial_name(0, name, (int)sizeof(name), unit, (int)sizeof(unit));
+  ok("partial 0 is Mrr per dyne-cm",
+     ierr == GF_OK && strcmp(name, "Mrr") == 0 && strncmp(unit, "m/dyne-cm", 9) == 0);
+  ierr = gf3d_partial_name(9, name, (int)sizeof(name), unit, (int)sizeof(unit));
+  ok("partial 9 is tim per second",
+     ierr == GF_OK && strcmp(name, "tim") == 0 && strncmp(unit, "m/s", 3) == 0);
+  ierr = gf3d_partial_name(6, name, (int)sizeof(name), NULL, 0);
+  ok("partial 6 is lat, unit buffer NULL", ierr == GF_OK && strcmp(name, "lat") == 0);
+  ok_status("partial index 10 refused",
+            gf3d_partial_name(10, name, (int)sizeof(name), unit, (int)sizeof(unit)),
+            GF_ERR_ARG);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 5. locating the validation source\n");
+
+  ierr = read_cmtsolution(cmtpath, &src);
+  ok("CMTSOLUTION parsed", ierr == 0);
+  if (ierr != 0) return 1;
+  printf("       %.4f, %.4f at %.2f km, hdur %.1f s, shift %.1f s\n",
+         src.latitude, src.longitude, src.depth_km, src.hdur, src.time_shift);
+
+  ierr = gf3d_locate(h, src.latitude, src.longitude, src.depth_km, &loc);
+  ok_status("gf3d_locate", ierr, GF_OK);
+  if (ierr != GF_OK) return 1;
+  printf("       element %d (%s) at xi,eta,gamma = %.6f %.6f %.6f\n",
+         loc.ielem, loc.morton_hex, loc.xi, loc.eta, loc.gamma);
+  ok("element index is in range", loc.ielem >= 1 && loc.ielem <= info.nelem);
+  ok("Morton code came back", strlen(loc.morton_hex) > 0);
+  ok("the mapped point is where it was asked for", loc.distance_km < 1.0e-6);
+  ok("xi is inside the accepted range", fabs(loc.xi) <= 1.1);
+  ok("the 27-anchor residual is small", loc.anchor_err < 1.0e-5);
+
+  /* the NaN that would otherwise reach the kd-tree's own stop */
+  ok_status("NaN latitude refused",
+            gf3d_locate(h, NAN, src.longitude, src.depth_km, &loc), GF_ERR_ARG);
+  ok_status("a point on the far side of the planet refused",
+            gf3d_locate(h, -src.latitude, src.longitude + 180.0, 10.0, &loc),
+            GF_ERR_NO_ELEMENT);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 6. the plan\n");
+
+  ierr = gf3d_get_plan(h, &src, -1.0, &plan);
+  ok_status("gf3d_get_plan with specfem's own t0", ierr, GF_OK);
+  if (ierr != GF_OK) return 1;
+  nt = plan.nt;
+  printf("       nt = %d (%d stored + %d prepended), dt_sub = %g, b = %g\n",
+         plan.nt, plan.nt_db, plan.npad, plan.dt_sub, plan.t_first);
+  ok("nt is positive", nt > 0);
+  ok("nt is the stored length plus the padding", plan.nt == plan.nt_db + plan.npad);
+  ok("dt_sub is dt times the subsampling",
+     fabs(plan.dt_sub - plan.dt * plan.subsample_step) < 1.0e-12 * plan.dt_sub);
+  ok("the axis starts at or before -1.5*hdur", plan.t_first <= -1.5 * src.hdur);
+  ok("a Heaviside conversion for a moment tensor", plan.kind_stf == 2);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 7. seismograms\n");
+
+  seis = (double *)malloc((size_t)nsta * GF_NCOMP * nt * sizeof(double));
+  t = (double *)malloc((size_t)nt * sizeof(double));
+  onset = (double *)malloc((size_t)nsta * sizeof(double));
+  if (seis == NULL || t == NULL || onset == NULL) {
+    fprintf(stderr, "out of memory\n");
+    return 1;
+  }
+
+  ierr = gf3d_seismograms(h, &src, -1.0, nt, seis, t, onset, &loc);
+  ok_status("gf3d_seismograms", ierr, GF_OK);
+  if (ierr != GF_OK) return 1;
+
+  {
+    int allfinite = 1, nonzero = 0;
+    double peak = 0.0, dtmax = 0.0;
+    for (i = 0; i < nsta * GF_NCOMP * nt; i++) {
+      if (!isfinite(seis[i])) allfinite = 0;
+      if (seis[i] != 0.0) nonzero = 1;
+      if (fabs(seis[i]) > peak) peak = fabs(seis[i]);
+    }
+    ok("every sample is finite", allfinite);
+    ok("the traces are not all zero", nonzero);
+    printf("       peak displacement %.4e m, onset ratio %.2e\n", peak, onset[0]);
+
+    for (i = 1; i < nt; i++) {
+      double d = fabs((t[i] - t[i-1]) - plan.dt_sub);
+      if (d > dtmax) dtmax = d;
+    }
+    ok_err("the time axis is uniform at dt_sub", dtmax, 1.0e-12 * plan.dt_sub);
+    ok_err("t[0] is the planned first sample", fabs(t[0] - plan.t_first),
+           1.0e-12 * fabs(plan.t_first));
+  }
+
+  ok_status("the wrong nt refused",
+            gf3d_seismograms(h, &src, -1.0, nt + 1, seis, t, onset, NULL), GF_ERR_ARG);
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 8. partial derivatives, and the identity they satisfy\n");
+
+  ierr = gf3d_ndp(2, &ndp);
+  dp = (double *)malloc((size_t)nsta * ndp * GF_NCOMP * nt * sizeof(double));
+  if (dp == NULL) { fprintf(stderr, "out of memory\n"); return 1; }
+
+  ierr = gf3d_partials(h, &src, -1.0, 2, nt, ndp, seis, dp, t, onset, NULL);
+  ok_status("gf3d_partials, itypsokern = 2", ierr, GF_OK);
+  if (ierr != GF_OK) return 1;
+
+  {
+    int allfinite = 1;
+    double worst = 0.0, peak = 0.0;
+
+    for (i = 0; i < nsta * ndp * GF_NCOMP * nt; i++)
+      if (!isfinite(dp[i])) allfinite = 0;
+    ok("every partial is finite", allfinite);
+
+    /*
+     * The identity of Stage 6: the six moment-tensor partials are per
+     * dyne-cm and linear, so contracting them with the CMTSOLUTION's own
+     * components must give the seismogram back. It needs no reference file,
+     * and no transposition of the four-dimensional index can survive it.
+     */
+    for (i = 0; i < nsta; i++) {
+      for (j = 0; j < GF_NCOMP; j++) {
+        for (k = 0; k < nt; k++) {
+          double s = seis[(i * GF_NCOMP + j) * nt + k];
+          double sum = 0.0;
+          for (ip = 0; ip < GF_NDP_MT; ip++)
+            sum += src.moment[ip] * dp[((i * ndp + ip) * GF_NCOMP + j) * nt + k];
+          if (fabs(s) > peak) peak = fabs(s);
+          if (fabs(sum - s) > worst) worst = fabs(sum - s);
+        }
+      }
+    }
+    ok_err("sum(M_v dp_v) reproduces the seismogram", worst / peak, 1.0e-12);
+  }
+
+  ok_status("the wrong ndp refused",
+            gf3d_partials(h, &src, -1.0, 2, nt, GF_NDP_MT, seis, dp, t, onset, NULL),
+            GF_ERR_ARG);
+  ok_status("itypsokern 0 refused (use gf3d_seismograms)",
+            gf3d_partials(h, &src, -1.0, 0, nt, 0, seis, dp, t, onset, NULL),
+            GF_ERR_ARG);
+
+  /* partials of a force source have nothing to differentiate against */
+  memset(&force, 0, sizeof(force));
+  force.source_type = GF_SRC_FORCE;
+  force.latitude = src.latitude;
+  force.longitude = src.longitude;
+  force.depth_km = src.depth_km;
+  force.hdur = 45.0;
+  force.force_stf = 0;
+  force.force_factor = 1.0e15;
+  force.force_dir[0] = 1.0;
+  ok_status("partials of a force source refused",
+            gf3d_partials(h, &force, -1.0, 1, nt, GF_NDP_MT, seis, dp, t, onset, NULL),
+            GF_ERR_ARG);
+
+  /* but its seismograms are fine */
+  {
+    gf3d_plan fplan;
+    ierr = gf3d_get_plan(h, &force, -1.0, &fplan);
+    ok_status("a force source plans", ierr, GF_OK);
+    if (ierr == GF_OK && fplan.nt <= nt) {
+      ierr = gf3d_seismograms(h, &force, -1.0, fplan.nt, seis, t, onset, NULL);
+      ok_status("a force source extracts", ierr, GF_OK);
+    }
+  }
+
+  /* a source type that is neither */
+  {
+    gf3d_source bad = src;
+    bad.source_type = 7;
+    ok_status("an unknown source type refused",
+              gf3d_get_plan(h, &bad, -1.0, &plan), GF_ERR_ARG);
+  }
+
+  /* ---------------------------------------------------------------- */
+  printf("\n 9. handles\n");
+
+  ok_status("handle 0 refused", gf3d_get_info(0, &info), GF_ERR_ARG);
+  ok_status("handle -1 refused", gf3d_get_info(-1, &info), GF_ERR_ARG);
+  ok_status("handle 99 refused", gf3d_get_info(99, &info), GF_ERR_ARG);
+
+  /*
+   * Two handles on the same database at once, then closing one and using
+   * the other. Closing releases the process-wide search tree even though
+   * the second handle is still open, so the extraction below is what
+   * proves the tree is rebuilt on demand rather than silently missing.
+   */
+  ierr = gf3d_open(dbpath, 0, &h2);
+  ok_status("a second handle on the same database", ierr, GF_OK);
+  ok("the two handles differ", h2 != h);
+
+  if (ierr == GF_OK) {
+    ierr = gf3d_seismograms(h2, &src, -1.0, nt, seis, t, onset, NULL);
+    ok_status("the second handle extracts", ierr, GF_OK);
+
+    ierr = gf3d_close(h);
+    ok_status("closing the first handle", ierr, GF_OK);
+
+    ierr = gf3d_seismograms(h2, &src, -1.0, nt, seis, t, onset, NULL);
+    ok_status("the second handle still extracts", ierr, GF_OK);
+
+    ok_status("the closed handle is refused", gf3d_get_info(h, &info), GF_ERR_ARG);
+
+    ierr = gf3d_close(h2);
+    ok_status("closing the second handle", ierr, GF_OK);
+    ok_status("closing it twice is refused", gf3d_close(h2), GF_ERR_ARG);
+  }
+
+  free(seis);
+  free(dp);
+  free(t);
+  free(onset);
+
+  printf("\n");
+  if (nfail == 0) {
+    printf(" test_gf_capi: all assertions passed\n\n");
+    return 0;
+  }
+  printf(" test_gf_capi: %d assertion(s) FAILED\n\n", nfail);
+  return 1;
+}

--- a/tests/gf3d/test_gf_capi.makefile
+++ b/tests/gf3d/test_gf_capi.makefile
@@ -1,0 +1,30 @@
+# includes default Makefile from previous configuration
+include Makefile
+
+# test target
+default: test_gf_capi
+
+## compilation directories
+O := ./obj
+L := ./lib
+I := ./include
+
+# The only test in the tree that compiles C, because it is the only one
+# testing a C ABI. It sees exactly what a downstream C caller sees:
+# include/gf3d.h and lib/libgf3d.so, and nothing from ./obj.
+#
+# Linked against the *shared* library on purpose -- test_gf3d_ext covers the
+# archive -- with an rpath, because the runner executes ./bin/test_gf_capi
+# with no LD_LIBRARY_PATH set.
+#
+# Linked with ${CC}, not the Fortran driver: ifort and ifx add their own
+# for_main.o to every link, which defines main() and calls MAIN__, so a C
+# main collides with it ("multiple definition of `main'"). Nothing is lost
+# by using the C driver, because libgf3d.so records the Fortran runtime and
+# HDF5 as DT_NEEDED and the dynamic linker follows that -- which is also
+# exactly how ctypes loads it, so this link exercises the same property the
+# Python package depends on.
+test_gf_capi:
+	${CC} -c $(CPPFLAGS) $(CFLAGS) -I$I -o $O/test_gf_capi.o test_gf_capi.c
+	${CC} -o ./bin/test_gf_capi $O/test_gf_capi.o \
+		$L/libgf3d.so -Wl,-rpath,$(abspath $L) -lm

--- a/tests/gf3d/test_gf_python.py
+++ b/tests/gf3d/test_gf_python.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
 
 import numpy as np
@@ -113,6 +115,30 @@ def main(argv):
         gf3d.Database("/nonexistent/gf3d/database")
     except gf3d.GF3DError as exc:
         ok("the message names the path", "/nonexistent/gf3d/database" in str(exc))
+
+    # Stations before info, on a database that has cached neither.
+    #
+    # These properties compose -- stations needs info -- and both call the
+    # library under its lock, so with a non-reentrant lock this deadlocks
+    # unless something happened to populate the cache first. Every other
+    # caller here reads info first and hid it. Do it in this order, once,
+    # and with a watchdog, because the symptom of a regression is a hang
+    # rather than a failure and a hung test tells nobody anything.
+    def _first_call_order():
+        fresh = gf3d.Database(dbpath)
+        try:
+            return fresh.station_ids
+        finally:
+            fresh.close()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_first_call_order)
+        try:
+            ids_first = future.result(timeout=60)
+            ok("station_ids works before info is cached", len(ids_first) > 0)
+        except FuturesTimeout:
+            ok("station_ids works before info is cached (DEADLOCK)", False)
+            return 1
 
     db = gf3d.Database(dbpath)
     ok("the database is open", not db.closed)

--- a/tests/gf3d/test_gf_python.py
+++ b/tests/gf3d/test_gf_python.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python
+"""test_gf_python -- the ctypes package against xgf3d itself.
+
+Tier 2: needs the shared library and a built example database.
+
+The oracle is the executable. Everything the Python package returns has
+come through a chain -- ctypes, the bind(C) facade, the transposing copy --
+that the Fortran tests do not exercise, and the way to check that chain end
+to end is to ask ``xgf3d --seis --format ascii`` for the same source and
+compare columns. Those ASCII files are the same ones the workflow's
+comparison harness gates on, so agreement here ties the in-memory API to
+the numbers the project is validated by.
+
+The rest is the package's own contract: shapes, station order, the names
+and units of the partials, the linearity identity the moment-tensor
+partials satisfy, and -- the reason the facade exists -- that every
+mistake raises a Python exception instead of ending the interpreter.
+
+Usage: test_gf_python.py <xgf3d> <GFDB> <CMTSOLUTION> [FORCESOLUTION] [second GFDB]
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+import gf3d
+
+TOL = 1.0e-12
+
+nfail = 0
+
+
+def ok(name, cond):
+    global nfail
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}")
+        nfail += 1
+
+
+def ok_err(name, err, tol=TOL):
+    global nfail
+    if err <= tol and not np.isnan(err):
+        print(f"  ok   {name:<40s} error = {err:12.5e}  (tol {tol:12.5e})")
+    else:
+        print(f"  FAIL {name:<40s} error = {err:12.5e}  (tol {tol:12.5e})")
+        nfail += 1
+
+
+def ok_raises(name, code, fn, *args, **kwargs):
+    """The call must raise GF3DError with this status, and leave us running."""
+    global nfail
+    try:
+        fn(*args, **kwargs)
+    except gf3d.GF3DError as exc:
+        if code is None or exc.code == code:
+            print(f"  ok   {name:<40s} -> {exc.name}")
+            return
+        print(f"  FAIL {name:<40s} -> {exc.name} (wanted code {code})")
+        nfail += 1
+        return
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL {name:<40s} -> {type(exc).__name__}: {exc}")
+        nfail += 1
+        return
+    print(f"  FAIL {name:<40s} -> no exception")
+    nfail += 1
+
+
+def read_ascii(path):
+    """One NET.STA.gf3d.txt: the time column and the three components."""
+    data = np.loadtxt(path, comments="#")
+    return data[:, 0], data[:, 1:4]
+
+
+def main(argv):
+    if len(argv) < 4:
+        print(__doc__)
+        return 2
+
+    xgf3d = Path(argv[1]).resolve()
+    dbpath = Path(argv[2]).resolve()
+    cmtpath = Path(argv[3]).resolve()
+    forcepath = Path(argv[4]).resolve() if len(argv) > 4 and argv[4] else None
+    dbpath2 = Path(argv[5]).resolve() if len(argv) > 5 and argv[5] else None
+
+    print()
+    print(" ******************************")
+    print(" test_gf_python")
+    print(" ******************************")
+    print()
+
+    # ------------------------------------------------------------------
+    print(" 1. the package and the library it found")
+    print(f"       library: {gf3d.library_path}")
+    print(f"       version: {gf3d.library_version()}")
+    ok("a version string came back", len(gf3d.library_version()) > 0)
+    # the struct layout check runs at import; getting here means it passed
+    ok("the struct layouts agree with the header", True)
+
+    # ------------------------------------------------------------------
+    print("\n 2. opening")
+
+    ok_raises("a database that is not there", gf3d.GF_ERR_NO_PATH,
+              gf3d.Database, "/nonexistent/gf3d/database")
+    try:
+        gf3d.Database("/nonexistent/gf3d/database")
+    except gf3d.GF3DError as exc:
+        ok("the message names the path", "/nonexistent/gf3d/database" in str(exc))
+
+    db = gf3d.Database(dbpath)
+    ok("the database is open", not db.closed)
+    print(f"       {db!r}")
+
+    info = db.info
+    ok("info is complete", info["nelem"] > 0 and info["nstations"] > 0 and info["dt"] > 0)
+    ok("r_planet and rhoav are physical", info["r_planet"] > 1e6 and info["rhoav"] > 100)
+
+    ids = db.station_ids
+    on_disk = sorted(p.stem for p in (dbpath / "stations").glob("*.h5"))
+    ok("station_ids are the station files, in order", ids == on_disk)
+    print(f"       stations: {ids}")
+
+    stations = db.stations
+    ok("every station carries a network and a name",
+       all(s.network and s.station and s.id == f"{s.network}.{s.station}" for s in stations))
+
+    # ------------------------------------------------------------------
+    print("\n 3. the source, and where it sits")
+
+    cmt = gf3d.CMTSource.read(cmtpath)
+    print(f"       {cmt.latitude}, {cmt.longitude} at {cmt.depth} km, "
+          f"hdur {cmt.hdur} s, shift {cmt.time_shift} s, event {cmt.event_name}")
+    ok("the moment tensor is six numbers in dyne-cm",
+       len(cmt.tensor) == 6 and abs(cmt.Mrr) > 1e20)
+    ok("the origin time was parsed", cmt.origin_time is not None)
+    ok("the centroid time is the origin plus the shift",
+       cmt.centroid_time is not None
+       and abs((cmt.centroid_time - cmt.origin_time).total_seconds() - cmt.time_shift) < 1e-6)
+
+    loc = db.locate(cmt.latitude, cmt.longitude, cmt.depth)
+    print(f"       element {loc.ielem} ({loc.morton_hex}) "
+          f"at {loc.xi:.6f} {loc.eta:.6f} {loc.gamma:.6f}")
+    ok("the point was found where it was asked for", loc.distance_km < 1e-6)
+
+    ok_raises("a NaN latitude", gf3d.GF_ERR_ARG, db.locate, float("nan"), 0.0, 10.0)
+    ok_raises("the far side of the planet", gf3d.GF_ERR_NO_ELEMENT,
+              db.locate, -cmt.latitude, cmt.longitude + 180.0, 10.0)
+
+    plan = db.plan(cmt)
+    print(f"       nt = {plan.nt}, dt_sub = {plan.dt_sub}, t_first = {plan.t_first}")
+    ok("the plan is the stored length plus the padding", plan.nt == plan.nt_db + plan.npad)
+    ok("a Heaviside conversion for a moment tensor", plan.kind_stf == 2)
+    ok("the plan's own axis matches the arithmetic",
+       np.allclose(plan.times, plan.t_first + np.arange(plan.nt) * plan.dt_sub, atol=0))
+
+    # ------------------------------------------------------------------
+    print("\n 4. seismograms and partials")
+
+    r = db.partials(cmt)
+    nsta = len(ids)
+    ok("data is (nstations, 3, nt)", r.data.shape == (nsta, 3, plan.nt))
+    ok("dp is (nstations, 10, 3, nt)", r.dp.shape == (nsta, gf3d.GF_NDP_LOC, 3, plan.nt))
+    ok("t is (nt,)", r.t.shape == (plan.nt,))
+    ok("everything is finite", np.isfinite(r.data).all() and np.isfinite(r.dp).all())
+    ok("the traces are not all zero", np.abs(r.data).max() > 0)
+
+    ok("the partial names are GF3DF's order",
+       r.dp_names == ["Mrr", "Mtt", "Mpp", "Mrt", "Mrp", "Mtp", "lat", "lon", "dep", "tim"])
+    ok("the units are per dyne-cm, degree, km and second",
+       r.dp_units[0] == "m/dyne-cm" and r.dp_units[6] == "m/deg"
+       and r.dp_units[8] == "m/km" and r.dp_units[9] == "m/s")
+
+    # the identity of Stage 6, which no transposition of a four-dimensional
+    # index survives
+    lin = (r.dp[:, :6] * np.asarray(cmt.tensor)[None, :, None, None]).sum(axis=1)
+    ok_err("sum(M_v dp_v) reproduces the seismogram",
+           np.abs(lin - r.data).max() / np.abs(r.data).max())
+
+    ok("trace() and partial() select the same data",
+       np.array_equal(r.trace(ids[0], "Z"), r.data[0, 2])
+       and np.array_equal(r.partial(ids[0], "N", "dep"), r.dp[0, 8, 0]))
+
+    r1 = db.partials(cmt, kind=1)
+    ok("kind=1 gives six partials", r1.dp.shape[1] == gf3d.GF_NDP_MT)
+    ok_err("kind=1 and kind=2 agree on the six",
+           np.abs(r1.dp - r.dp[:, :6]).max() / np.abs(r.dp[:, :6]).max())
+    ok_err("and on the seismogram",
+           np.abs(r1.data - r.data).max() / np.abs(r.data).max())
+
+    try:
+        db.partials(cmt, kind=3)
+        ok("kind=3 refused", False)
+    except ValueError:
+        ok("kind=3 refused", True)
+
+    # ------------------------------------------------------------------
+    print("\n 5. against xgf3d --seis --format ascii")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cmd = [str(xgf3d), "--seis", str(dbpath), str(cmtpath), tmp, "--format", "ascii"]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        ok("xgf3d ran", proc.returncode == 0)
+        if proc.returncode != 0:
+            print(proc.stdout[-2000:])
+            print(proc.stderr[-2000:])
+        else:
+            worst_t = 0.0
+            worst_d = 0.0
+            for ista, sid in enumerate(ids):
+                t_ref, d_ref = read_ascii(Path(tmp) / f"{sid}.gf3d.txt")
+                worst_t = max(worst_t, np.abs(t_ref - r.t).max())
+                # the ASCII carries (nt, 3) as N, E, Z; the array is (3, nt)
+                diff = np.abs(d_ref.T - r.data[ista])
+                worst_d = max(worst_d, diff.max() / max(np.abs(d_ref).max(), 1e-300))
+            ok_err("the time axis matches the executable", worst_t)
+            ok_err("every station's trace matches the executable", worst_d)
+
+    # ------------------------------------------------------------------
+    print("\n 6. a force source")
+
+    if forcepath is not None and forcepath.exists():
+        force = gf3d.ForceSource.read(forcepath)
+        print(f"       f0 {force.f0}, stf {force.stf}, factor {force.factor:g}, "
+              f"direction {force.direction}")
+        fr = db.seismograms(force)
+        ok("force seismograms are (nstations, 3, nt)",
+           fr.data.shape[0] == nsta and fr.data.shape[1] == 3)
+        ok("they are finite and not all zero",
+           np.isfinite(fr.data).all() and np.abs(fr.data).max() > 0)
+        ok("a force source has no partials", fr.dp is None)
+        ok_raises("partials of a force source", gf3d.GF_ERR_ARG, db.partials, force)
+    else:
+        print("       (no FORCESOLUTION in this example, skipped)")
+
+    # ------------------------------------------------------------------
+    print("\n 7. obspy, if it is installed")
+
+    try:
+        import obspy  # noqa: F401
+    except ImportError:
+        print("       (obspy not installed, skipped)")
+    else:
+        st = r.to_stream()
+        ok("one trace per station and component", len(st) == 3 * nsta)
+        tr = st[2]
+        ok("the channel follows the solver's naming", tr.stats.channel == "BXZ")
+        ok("the sample spacing is the stored one", abs(tr.stats.delta - plan.dt_sub) < 1e-6)
+        ok("the data survived the trip", np.array_equal(tr.data, r.data[0, 2]))
+        start = tr.stats.starttime
+        expected = obspy.UTCDateTime(cmt.centroid_time) + float(r.t[0])
+        ok("the start time is the centroid time plus t[0]", abs(start - expected) < 1e-6)
+
+    # ------------------------------------------------------------------
+    print("\n 8. closing, and a second database")
+
+    if dbpath2 is not None and (dbpath2 / "mesh_info.h5").exists():
+        # The two-database case: opening the second re-installs specfem's
+        # process-wide globals, and the facade re-installs the first
+        # handle's before every call. If it did not, this extraction would
+        # come back subtly different -- the topography grid indexed with the
+        # other database's dimensions.
+        db2 = gf3d.Database(dbpath2)
+        print(f"       second: {db2!r}")
+        r2 = db2.seismograms(cmt)
+        ok("the second database extracts", np.isfinite(r2.data).all())
+
+        again = db.partials(cmt)
+        ok("the first database is bit-for-bit unchanged",
+           np.array_equal(again.data, r.data) and np.array_equal(again.dp, r.dp))
+        db2.close()
+    else:
+        print("       (only one example database is built, skipped)")
+        again = db.partials(cmt)
+        ok("a repeated extraction is bit-for-bit identical",
+           np.array_equal(again.data, r.data) and np.array_equal(again.dp, r.dp))
+
+    db.close()
+    ok("the database is closed", db.closed)
+    db.close()
+    ok("closing twice is harmless", db.closed)
+    ok_raises("using a closed database", gf3d.GF_ERR_ARG, db.locate, 0.0, 0.0, 10.0)
+
+    with gf3d.Database(dbpath) as ctx:
+        ok("the context manager opens", not ctx.closed)
+    ok("and closes on the way out", ctx.closed)
+
+    print()
+    if nfail == 0:
+        print(" test_gf_python: all assertions passed\n")
+        return 0
+    print(f" test_gf_python: {nfail} assertion(s) FAILED\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/gf3d/test_gf_source.f90
+++ b/tests/gf3d/test_gf_source.f90
@@ -1,0 +1,476 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!----
+!---- test_gf_source -- the values route against the file route
+!----
+!---- Stage 9 gives the C/Python side a way to build a source from numbers
+!---- rather than from a file, because reading a file means get_cmt() and
+!---- get_force(), which `stop` on malformed input -- and a stop inside
+!---- lib/libgf3d.so kills the calling interpreter with no traceback.
+!----
+!---- That leaves two code paths where there was one, and they must agree.
+!---- This test writes a source file, reads it through the solver's own
+!---- reader, builds the same source from the same numbers through
+!---- gf_source_set_*, and compares. The oracle is the reader; what is being
+!---- checked is the transcription of everything the reader does *after*
+!---- parsing -- the half-duration clamps, the time-shift convention and the
+!---- non-dimensionalisation -- since that is what was copied out.
+!----
+!---- Tolerance: 1e-12 relative, not equality. The two routes are separate
+!---- compilation units evaluating the same expressions, and testing.md
+!---- forbids asserting equality of a value a test recomputes: the Intel CI
+!---- has twice failed such checks that no local target reproduces. An
+!---- error here of the size that matters -- a missing clamp, a forgotten
+!---- 1e7, a dropped division -- is a factor, not an ulp.
+!----
+!---- The second half checks the paths that used to be a `stop`: every one
+!---- returns an error code, sets a message, and leaves the program running.
+!---- That is the property the whole facade rests on, so it is asserted
+!---- rather than assumed.
+!----
+!---- Tier 1: no database, no HDF5, no MPI. Runs on every commit.
+!----
+
+  program test_gf_source
+
+  use gf_par, only: t_gf_source,gf_errmsg,GF_OK,GF_ERR_ARG,GF_SRC_CMT,GF_SRC_FORCE
+
+  use gf_shared_params, only: gf_init_shared_params
+
+  use gf_source, only: gf_read_cmt_source,gf_read_force_source, &
+                       gf_source_set_cmt,gf_source_set_force
+
+  use gf_manufactured, only: gf_report,gf_report_true
+
+  implicit none
+
+  ! the shipped regional example's own CMTSOLUTION values, so that the
+  ! numbers under test are the ones the project is validated with
+  double precision, parameter :: LAT = -5.8120d0
+  double precision, parameter :: LON = -75.2700d0
+  double precision, parameter :: DEP = 122.6000d0
+  double precision, parameter :: HDUR = 60.0000d0
+  double precision, parameter :: TSHIFT = 29.0000d0
+
+  double precision, parameter :: MRR = -7.590000d27
+  double precision, parameter :: MTT =  7.750000d27
+  double precision, parameter :: MPP = -1.600000d26
+  double precision, parameter :: MRT = -2.503000d28
+  double precision, parameter :: MRP =  4.200000d26
+  double precision, parameter :: MTP = -2.480000d27
+
+  ! the regional database's solver time step
+  double precision, parameter :: DT = 0.1d0
+
+  double precision, parameter :: TOL = 1.d-12
+
+  character(len=*), parameter :: CMTFILE = './OUTPUT_FILES/test_gf_source.CMTSOLUTION'
+  character(len=*), parameter :: FORCEFILE = './OUTPUT_FILES/test_gf_source.FORCESOLUTION'
+
+  integer :: nfail
+
+  nfail = 0
+
+  write(*,*)
+  write(*,*) '******************************'
+  write(*,*) 'test_gf_source'
+  write(*,*) '******************************'
+  write(*,*)
+
+  ! get_cmt reads NUMBER_OF_SIMULTANEOUS_RUNS and NOISE_TOMOGRAPHY, neither
+  ! of which has an initialiser in shared_par.f90, and both routes read
+  ! R_PLANET and RHOAV. A default t_gfdb leaves the Earth defaults standing,
+  ! which is what a tier-1 test wants: no database exists here.
+  call init_globals(nfail)
+
+  call test_cmt_agrees(nfail)
+  call test_cmt_clamp(nfail)
+  call test_force_agrees(nfail)
+  call test_refusals(nfail)
+
+  write(*,*)
+  if (nfail == 0) then
+    write(*,*) 'test_gf_source: all assertions passed'
+  else
+    write(*,*) 'test_gf_source: ',nfail,' assertion(s) FAILED'
+    stop 1
+  endif
+  write(*,*)
+
+  contains
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine init_globals(nfail)
+
+  use gf_par, only: t_gfdb
+
+  implicit none
+
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gfdb) :: db
+  integer :: ier
+
+  call gf_init_shared_params(db,ier)
+
+  call gf_report_true('shared parameters installed from a blank handle',ier == GF_OK,nfail)
+
+  end subroutine init_globals
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_cmt(filename,hdur_in,tshift_in)
+
+! a 13-line CMTSOLUTION, in the format get_cmt expects
+
+  implicit none
+
+  character(len=*), intent(in) :: filename
+  double precision, intent(in) :: hdur_in,tshift_in
+
+  ! local parameters
+  integer, parameter :: IOUT = 91
+
+  open(unit=IOUT,file=trim(filename),status='unknown',action='write')
+  write(IOUT,'(a)') 'PDE 1994  6  9  0 33 16.40 -13.8300  -67.5600 637.0 6.9 6.8 NORTHERN BOLIVIA'
+  write(IOUT,'(a)') 'event name:     test0001'
+  write(IOUT,'(a,f12.4)') 'time shift:  ',tshift_in
+  write(IOUT,'(a,f12.4)') 'half duration:',hdur_in
+  write(IOUT,'(a,f12.4)') 'latitude:    ',LAT
+  write(IOUT,'(a,f12.4)') 'longitude:   ',LON
+  write(IOUT,'(a,f12.4)') 'depth:       ',DEP
+  write(IOUT,'(a,es16.6)') 'Mrr:       ',MRR
+  write(IOUT,'(a,es16.6)') 'Mtt:       ',MTT
+  write(IOUT,'(a,es16.6)') 'Mpp:       ',MPP
+  write(IOUT,'(a,es16.6)') 'Mrt:       ',MRT
+  write(IOUT,'(a,es16.6)') 'Mrp:       ',MRP
+  write(IOUT,'(a,es16.6)') 'Mtp:       ',MTP
+  close(IOUT)
+
+  end subroutine write_cmt
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_force(filename,f0_in,stf_in,factor_in,dE,dN,dZ)
+
+! an 11-line FORCESOLUTION, in the globe's format (f0, not a half duration)
+
+  implicit none
+
+  character(len=*), intent(in) :: filename
+  double precision, intent(in) :: f0_in,factor_in,dE,dN,dZ
+  integer, intent(in) :: stf_in
+
+  ! local parameters
+  integer, parameter :: IOUT = 92
+
+  open(unit=IOUT,file=trim(filename),status='unknown',action='write')
+  write(IOUT,'(a)') 'FORCE  001'
+  write(IOUT,'(a,f12.4)') 'time shift:  ',0.d0
+  write(IOUT,'(a,f12.4)') 'f0:          ',f0_in
+  write(IOUT,'(a,f12.4)') 'latitude:    ',LAT
+  write(IOUT,'(a,f12.4)') 'longitude:   ',LON
+  write(IOUT,'(a,f12.4)') 'depth:       ',DEP
+  write(IOUT,'(a,i6)')    'source time function:',stf_in
+  write(IOUT,'(a,es16.6)') 'factor force source:',factor_in
+  write(IOUT,'(a,f12.4)') 'comp dir vect source E:',dE
+  write(IOUT,'(a,f12.4)') 'comp dir vect source N:',dN
+  write(IOUT,'(a,f12.4)') 'comp dir vect source Z:',dZ
+  close(IOUT)
+
+  end subroutine write_force
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  double precision function relerr(a,b)
+
+! relative difference, falling back to absolute when both are ~zero
+
+  implicit none
+
+  double precision, intent(in) :: a,b
+
+  ! local parameters
+  double precision :: scale
+
+  scale = max(abs(a),abs(b))
+  if (scale < 1.d-30) then
+    relerr = abs(a-b)
+  else
+    relerr = abs(a-b)/scale
+  endif
+
+  end function relerr
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine test_cmt_agrees(nfail)
+
+! the two routes on the shipped example's own moment tensor
+
+  implicit none
+
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gf_source) :: sfile,sval
+  double precision, dimension(6) :: m
+  integer :: ier,iv
+  character(len=16) :: label
+
+  write(*,*) '1. CMT: values route against get_cmt'
+
+  m = (/ MRR,MTT,MPP,MRT,MRP,MTP /)
+
+  call write_cmt(CMTFILE,HDUR,TSHIFT)
+
+  call gf_read_cmt_source(CMTFILE,DT,sfile,ier)
+  call gf_report_true('   get_cmt read the file',ier == GF_OK,nfail)
+  if (ier /= GF_OK) return
+
+  call gf_source_set_cmt(sval,LAT,LON,DEP,HDUR,TSHIFT,m,DT,ier)
+  call gf_report_true('   gf_source_set_cmt succeeded',ier == GF_OK,nfail)
+  if (ier /= GF_OK) return
+
+  call gf_report_true('   source_type is CMT',sval%source_type == GF_SRC_CMT,nfail)
+
+  call gf_report('   latitude   ',relerr(sval%latitude,sfile%latitude),TOL,nfail)
+  call gf_report('   longitude  ',relerr(sval%longitude,sfile%longitude),TOL,nfail)
+  call gf_report('   depth      ',relerr(sval%depth,sfile%depth),TOL,nfail)
+  call gf_report('   hdur       ',relerr(sval%hdur,sfile%hdur),TOL,nfail)
+  call gf_report('   tshift_src ',abs(sval%tshift_src - sfile%tshift_src),TOL,nfail)
+  call gf_report('   time shift ',relerr(sval%min_tshift_src_original, &
+                                         sfile%min_tshift_src_original),TOL,nfail)
+  call gf_report('   scale_moment',relerr(sval%scale_moment,sfile%scale_moment),TOL,nfail)
+
+  ! the six non-dimensional components, named one by one: the CI log is the
+  ! only trace of a run there, and "the moment tensor differs" would not say
+  ! which convention slipped
+  do iv = 1,6
+    write(label,'(a,i1,a)') '   moment(',iv,')  '
+    call gf_report(label,relerr(sval%moment_tensor(iv),sfile%moment_tensor(iv)),TOL,nfail)
+  enddo
+
+  ! and the round trip back to dyne-cm, which is what the partials are per
+  do iv = 1,6
+    write(label,'(a,i1,a)') '   dyne-cm(',iv,') '
+    call gf_report(label,relerr(sval%moment_tensor(iv)*sval%scale_moment,m(iv)),TOL,nfail)
+  enddo
+
+  end subroutine test_cmt_agrees
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine test_cmt_clamp(nfail)
+
+! the half-duration clamp: get_cmt.f90:397 replaces a null half duration by
+! 5*DT, and a values route that forgot it would give a Heaviside where the
+! solver gives a short error function
+
+  implicit none
+
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gf_source) :: sfile,sval
+  double precision, dimension(6) :: m
+  integer :: ier
+
+  write(*,*) '2. CMT: the half-duration clamp'
+
+  m = (/ MRR,MTT,MPP,MRT,MRP,MTP /)
+
+  call write_cmt(CMTFILE,0.d0,TSHIFT)
+
+  call gf_read_cmt_source(CMTFILE,DT,sfile,ier)
+  if (ier /= GF_OK) then
+    call gf_report_true('   get_cmt read the zero-hdur file',.false.,nfail)
+    return
+  endif
+
+  call gf_source_set_cmt(sval,LAT,LON,DEP,0.d0,TSHIFT,m,DT,ier)
+  if (ier /= GF_OK) then
+    call gf_report_true('   gf_source_set_cmt on zero hdur',.false.,nfail)
+    return
+  endif
+
+  call gf_report('   hdur clamped equally',relerr(sval%hdur,sfile%hdur),TOL,nfail)
+  call gf_report('   hdur is 5*dt        ',relerr(sval%hdur,5.d0*DT),TOL,nfail)
+
+  end subroutine test_cmt_clamp
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine test_force_agrees(nfail)
+
+! every source time function type the reader accepts
+
+  implicit none
+
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gf_source) :: sfile,sval
+  integer :: ier,k,istf
+  integer, dimension(4), parameter :: STF_KINDS = (/ 0,1,2,4 /)
+  double precision, parameter :: FACTOR = 1.d15
+  double precision, parameter :: DE = 1.d0, DN = 0.5d0, DZ = -2.d0
+  double precision :: f0
+  character(len=20) :: label
+
+  write(*,*) '3. force: values route against get_force, per source time function'
+
+  do k = 1,4
+    istf = STF_KINDS(k)
+
+    ! a Ricker reads f0 as a frequency, the others as a width; either way
+    ! the number is small enough that the 5*DT clamp is exercised on the
+    ! Gaussian branches
+    f0 = 0.05d0
+
+    call write_force(FORCEFILE,f0,istf,FACTOR,DE,DN,DZ)
+
+    call gf_read_force_source(FORCEFILE,DT,sfile,ier)
+    write(label,'(a,i1,a)') '   stf ',istf,' read      '
+    call gf_report_true(label,ier == GF_OK,nfail)
+    if (ier /= GF_OK) cycle
+
+    call gf_source_set_force(sval,LAT,LON,DEP,f0,0.d0,istf,FACTOR,DE,DN,DZ,DT,ier)
+    write(label,'(a,i1,a)') '   stf ',istf,' built     '
+    call gf_report_true(label,ier == GF_OK,nfail)
+    if (ier /= GF_OK) cycle
+
+    write(label,'(a,i1,a)') '   stf ',istf,' hdur      '
+    call gf_report(label,relerr(sval%hdur,sfile%hdur),TOL,nfail)
+
+    write(label,'(a,i1,a)') '   stf ',istf,' factor    '
+    call gf_report(label,relerr(sval%factor_force_source,sfile%factor_force_source),TOL,nfail)
+
+    write(label,'(a,i1,a)') '   stf ',istf,' dir E     '
+    call gf_report(label,relerr(sval%comp_dir_vect_source_E, &
+                                sfile%comp_dir_vect_source_E),TOL,nfail)
+    write(label,'(a,i1,a)') '   stf ',istf,' dir N     '
+    call gf_report(label,relerr(sval%comp_dir_vect_source_N, &
+                                sfile%comp_dir_vect_source_N),TOL,nfail)
+    write(label,'(a,i1,a)') '   stf ',istf,' dir Z     '
+    call gf_report(label,relerr(sval%comp_dir_vect_source_Z_UP, &
+                                sfile%comp_dir_vect_source_Z_UP),TOL,nfail)
+
+    write(label,'(a,i1,a)') '   stf ',istf,' type      '
+    call gf_report_true(label,sval%source_type == GF_SRC_FORCE .and. &
+                              sval%force_stf == sfile%force_stf,nfail)
+  enddo
+
+  end subroutine test_force_agrees
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine test_refusals(nfail)
+
+! the paths that are a `stop` in the readers
+!
+! Each of these would end the process inside get_force(); here each must
+! return GF_ERR_ARG, leave a message behind, and let the program continue --
+! which it demonstrably does, because the ones after it still run.
+
+  implicit none
+
+  integer, intent(inout) :: nfail
+
+  ! local parameters
+  type(t_gf_source) :: s
+  double precision, dimension(6) :: m
+  double precision :: nan,inf
+  integer :: ier
+
+  write(*,*) '4. refusals: what used to be a stop'
+
+  m = (/ MRR,MTT,MPP,MRT,MRP,MTP /)
+
+  ! built by bit pattern rather than by 0/0, which would trap under
+  ! -ffpe-trap=invalid before it could produce anything
+  nan = transfer(int(z'7FF8000000000000',kind=8),nan)
+  inf = transfer(int(z'7FF0000000000000',kind=8),inf)
+
+  ! get_force.f90:248 -- an unsupported source time function type
+  call gf_source_set_force(s,LAT,LON,DEP,0.05d0,0.d0,5,1.d15,1.d0,0.d0,0.d0,DT,ier)
+  call gf_report_true('   force_stf = 5 refused         ',ier == GF_ERR_ARG,nfail)
+  call gf_report_true('   ... with a message            ',len_trim(gf_errmsg) > 0,nfail)
+
+  ! get_force.f90:240 -- a monochromatic force with no period
+  call gf_source_set_force(s,LAT,LON,DEP,0.d0,0.d0,3,1.d15,1.d0,0.d0,0.d0,DT,ier)
+  call gf_report_true('   monochromatic f0 = 0 refused  ',ier == GF_ERR_ARG,nfail)
+
+  ! get_force.f90:272 -- a direction vector of zero length
+  call gf_source_set_force(s,LAT,LON,DEP,0.05d0,0.d0,0,1.d15,0.d0,0.d0,0.d0,DT,ier)
+  call gf_report_true('   zero direction vector refused ',ier == GF_ERR_ARG,nfail)
+
+  ! not a reader case: the library's own precondition
+  call gf_source_set_cmt(s,LAT,LON,DEP,HDUR,TSHIFT,m,0.d0,ier)
+  call gf_report_true('   dt = 0 refused (CMT)          ',ier == GF_ERR_ARG,nfail)
+
+  ! the ones that would reach the kd-tree's own stop through gf_locate
+  call gf_source_set_cmt(s,nan,LON,DEP,HDUR,TSHIFT,m,DT,ier)
+  call gf_report_true('   NaN latitude refused          ',ier == GF_ERR_ARG,nfail)
+
+  call gf_source_set_cmt(s,LAT,LON,inf,HDUR,TSHIFT,m,DT,ier)
+  call gf_report_true('   infinite depth refused        ',ier == GF_ERR_ARG,nfail)
+
+  m(3) = nan
+  call gf_source_set_cmt(s,LAT,LON,DEP,HDUR,TSHIFT,m,DT,ier)
+  call gf_report_true('   NaN moment component refused  ',ier == GF_ERR_ARG,nfail)
+  m(3) = MPP
+
+  call gf_source_set_force(s,LAT,nan,DEP,0.05d0,0.d0,0,1.d15,1.d0,0.d0,0.d0,DT,ier)
+  call gf_report_true('   NaN longitude refused (force) ',ier == GF_ERR_ARG,nfail)
+
+  ! and the program is still here to say so
+  call gf_source_set_cmt(s,LAT,LON,DEP,HDUR,TSHIFT,m,DT,ier)
+  call gf_report_true('   a good source still builds    ',ier == GF_OK,nfail)
+
+  end subroutine test_refusals
+
+  end program test_gf_source

--- a/tests/gf3d/test_gf_source.makefile
+++ b/tests/gf3d/test_gf_source.makefile
@@ -1,0 +1,35 @@
+# includes default Makefile from previous configuration
+include Makefile
+
+# test target
+default: test_gf_source
+
+## compilation directories
+O := ./obj
+
+# Kernel objects only -- no HDF5 archive exists after
+# 0.configure.default_make.sh.
+#
+# get_cmt.solver.o and get_force.solver.o are the point of this test: it
+# compares the values route in gf_source against the solver's own readers,
+# so both have to be here. They build through the $O/%.solver.o pattern rule
+# that `include Makefile` brings in (src/specfem3D/rules.mk), and neither
+# uses MPI or HDF5; get_cmt calls julian_day(), hence calendar.shared.o.
+#
+# gf_shared_params.gf3d.o installs the globals both readers depend on:
+# NUMBER_OF_SIMULTANEOUS_RUNS and NOISE_TOMOGRAPHY have no initialiser in
+# shared_par.f90, and R_PLANET/RHOAV want their Earth defaults left standing.
+OBJECTS = \
+	$O/gf_par.gf3d.o \
+	$O/gf_shared_params.gf3d.o \
+	$O/gf_source.gf3d.o \
+	$O/shared_par.shared_module.o \
+	$O/calendar.shared.o \
+	$O/get_cmt.solver.o \
+	$O/get_force.solver.o \
+	$(EMPTY_MACRO)
+
+# Serial link: ${FCCOMPILE_CHECK}, no $(MPILIBS), no $(LDFLAGS).
+test_gf_source: $(OBJECTS)
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -o ./bin/test_gf_source \
+		gf_manufactured.f90 test_gf_source.f90 -I./obj $(OBJECTS)

--- a/utils/green_function/.gitignore
+++ b/utils/green_function/.gitignore
@@ -1,0 +1,2 @@
+# an editable install of the gf3d package drops this here
+*.egg-info/

--- a/utils/green_function/gf3d/README.md
+++ b/utils/green_function/gf3d/README.md
@@ -1,0 +1,108 @@
+# `gf3d` — Green functions in memory
+
+A ctypes binding to `lib/libgf3d.so`, the Green function extraction library
+of `src/gf3d/`. It runs the same code `bin/xgf3d` runs; what it adds is
+getting seismograms and their partial derivatives into numpy arrays without
+a process launch and a SAC file per iteration, which is what a source
+inversion needs.
+
+## Building the library
+
+The package is pure Python, but the library it binds is not:
+
+```bash
+./configure --with-hdf5 HDF5_INC=<dir> HDF5_LIBS=-L<dir>
+make gf3d
+```
+
+That writes `lib/libgf3d.so` (and `lib/libgf3d.a`, `include/gf3d.h`,
+`include/gf3d.mod` for C and Fortran callers). The HDF5 library directories
+are baked into the shared object as an rpath, so nothing needs
+`LD_LIBRARY_PATH` — except the compiler's own runtime, if the tree was
+built with a module-provided compiler.
+
+## Using it
+
+```bash
+pip install -e utils/green_function          # or set PYTHONPATH
+```
+
+```python
+import numpy as np
+import gf3d
+
+with gf3d.Database("EXAMPLES/green_function_database/regional/GFDB") as db:
+    cmt = gf3d.CMTSource.read(".../validation_data/CMTSOLUTION")
+    r = db.partials(cmt)
+
+    r.data          # (nstations, 3, nt), metres, components N, E, Z
+    r.t             # (nt,), seconds, t = 0 at the centroid time
+    r.dp            # (nstations, 10, 3, nt)
+    r.dp_names      # ['Mrr','Mtt','Mpp','Mrt','Mrp','Mtp','lat','lon','dep','tim']
+    r.dp_units      # ['m/dyne-cm', ..., 'm/deg', 'm/deg', 'm/km', 'm/s']
+    r.station_ids   # ['IU.LVC', 'IU.SDV', 'IU.SJG']
+```
+
+The partials are analytic and exactly linear in the moment tensor, so
+
+```python
+(r.dp[:, :6] * np.asarray(cmt.tensor)[None, :, None, None]).sum(1)
+```
+
+reproduces `r.data` to round-off with the CMTSOLUTION's own numbers, in
+dyne·cm. That identity is the cheapest check that an inversion is using the
+partials the way the library means them.
+
+`db.seismograms(source)` skips the partials. `db.plan(source)` answers what
+the output axis will be without extracting anything. `db.locate(lat, lon,
+depth_km)` says which element a point falls in. A `ForceSource` works
+wherever a `CMTSource` does, except that it has no partials.
+
+`Result.to_stream()` returns an obspy `Stream` if obspy is installed
+(`pip install -e 'utils/green_function[obspy]'`); nothing else in the
+package needs it.
+
+## Things worth knowing
+
+**`t = 0` is the centroid time**, not the origin time. The CMTSOLUTION's
+`time shift` is carried in `cmt.time_shift` and applied only when an
+absolute start time is needed, as `to_stream()` does. Putting it into the
+trace instead is a mistake that looks right in isolation and is 29 seconds
+wrong against real data for the shipped example.
+
+**Errors are exceptions, never a crash.** Every failure — a database that
+is not there, a source outside it, a NaN, a closed handle — raises
+`GF3DError` with `.code`, `.name` and `.message`. `err.code ==
+gf3d.GF_ERR_NO_ELEMENT` is the one an inversion should expect: a trial
+source that wandered outside the database.
+
+**The library is not thread-safe** and this package serialises calls on a
+module-level lock. The process-wide state is the last error message, the
+search tree, and specfem's own parameter module. Extraction is a C call, so
+other Python threads keep running; they just wait at the library's door.
+
+**Two databases can be open at once**, but the search tree is rebuilt each
+time an extraction switches between them, so alternating is slow. Two
+databases of *different planets or topography grids* must not be used
+alternately at all: specfem holds one set of grid dimensions per process.
+
+**The onset warning** fires when a trace already carries more than about
+1e-3 of its peak at the first sample. It means the source time function
+conversion is reaching back past the start of the stored record and the
+first arrivals may be contaminated — a longer reciprocal run, or a later
+`t0`, is the cure. It is a warning and not an error because whether it
+matters depends on the arrival being measured.
+
+**If two `gf3d` packages collide.** The name is shared with the older
+standalone GF3D Python package, which reimplemented extraction over h5py.
+This one supersedes it and the two cannot live in one environment.
+
+## Relation to the rest of the tree
+
+| | |
+|---|---|
+| `include/gf3d.h` | the C ABI this binds, and the document of record for units, shapes and index order |
+| `src/gf3d/gf3d_capi.F90` | the `bind(C)` façade behind it |
+| `src/gf3d/gf3d.F90` | the same library for a Fortran caller (`use gf3d`) |
+| `bin/xgf3d` | the command-line tool, for SAC and ASCII output |
+| `tests/gf3d/9f.test_gf_python.sh` | checks this package against `xgf3d`'s own output |

--- a/utils/green_function/gf3d/__init__.py
+++ b/utils/green_function/gf3d/__init__.py
@@ -1,0 +1,81 @@
+"""Green function extraction from a specfem3d_globe reciprocal database.
+
+A thin ctypes binding over ``lib/libgf3d.so``, which is the same code
+``bin/xgf3d`` runs. Nothing here reimplements any part of the extraction:
+the point of the package is to get seismograms and their partial
+derivatives into memory, for an inversion loop that cannot afford a process
+launch and a SAC file per iteration.
+
+    import gf3d
+
+    with gf3d.Database("EXAMPLES/green_function_database/regional/GFDB") as db:
+        cmt = gf3d.CMTSource.read(".../validation_data/CMTSOLUTION")
+        r = db.partials(cmt)
+
+        r.data          # (nstations, 3, nt) metres, components N, E, Z
+        r.t             # (nt,) seconds, t = 0 at the centroid time
+        r.dp            # (nstations, 10, 3, nt) partial derivatives
+        r.dp_names      # ['Mrr', ..., 'Mtp', 'lat', 'lon', 'dep', 'tim']
+        r.station_ids   # ['IU.LVC', 'IU.SDV', 'IU.SJG']
+
+The partials are analytic and linear, so the moment-tensor half satisfies
+
+    (r.dp[:, :6] * cmt.tensor[None, :, None, None]).sum(1)  ==  r.data
+
+to round-off, with the CMTSOLUTION's own numbers, in dyne-cm.
+
+Finding the library
+-------------------
+``$GF3D_LIB`` if set, else ``<repo>/lib/libgf3d.so`` relative to this file,
+else the system search path. Build it with ``./configure --with-hdf5`` and
+``make gf3d``.
+
+Threads
+-------
+The library keeps process-wide state and is not thread-safe; every call
+here is serialised on a module-level lock. Extraction is a C call, so other
+Python threads keep running while it is inside the library.
+"""
+
+from ._lib import (
+    GF_NCOMP,
+    GF_NDP_LOC,
+    GF_NDP_MT,
+    GF_OK,
+    GF_ERR_ARG,
+    GF_ERR_GEOMETRY,
+    GF_ERR_INCOMPLETE,
+    GF_ERR_NO_ELEMENT,
+    GF_ERR_NO_PATH,
+    GF3DError,
+    library_path,
+    version as library_version,
+)
+from .database import Database, Location, Plan, Result, Station, open
+from .sources import CMTSource, ForceSource
+
+__all__ = [
+    "Database",
+    "open",
+    "CMTSource",
+    "ForceSource",
+    "Result",
+    "Plan",
+    "Location",
+    "Station",
+    "GF3DError",
+    "library_version",
+    "library_path",
+    "GF_NCOMP",
+    "GF_NDP_MT",
+    "GF_NDP_LOC",
+    "GF_OK",
+    "GF_ERR_ARG",
+    "GF_ERR_NO_PATH",
+    "GF_ERR_NO_ELEMENT",
+    "GF_ERR_GEOMETRY",
+    "GF_ERR_INCOMPLETE",
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/utils/green_function/gf3d/_lib.py
+++ b/utils/green_function/gf3d/_lib.py
@@ -1,0 +1,394 @@
+"""ctypes binding to lib/libgf3d.so.
+
+This module is the transcription of ``include/gf3d.h`` and nothing else: the
+structures, the entry points, the library search, and the translation of a
+status code into an exception. Everything with an opinion about how to use
+them lives in :mod:`gf3d.database`.
+
+The header is the contract. Two things guard the transcription against
+drifting away from it:
+
+* ``gf3d_sizeof`` is called at load time and compared with
+  :func:`ctypes.sizeof` for all five structures, so a field added on one
+  side and not the other fails loudly at import rather than silently
+  returning shifted numbers;
+* every function is given an explicit ``argtypes`` and ``restype``, so a
+  wrong argument is a ``ctypes.ArgumentError`` at the call, not a
+  reinterpreted pointer.
+
+Thread safety
+-------------
+The library is not thread-safe. It keeps the last error message, the
+kd-tree that serves whichever database located most recently, and specfem's
+``shared_parameters`` in process-wide storage. Every call made through this
+module therefore takes ``LIBRARY_LOCK``. Extraction releases the GIL (it is
+a C call), so other Python threads keep running; they just cannot be inside
+the library at the same time.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import threading
+from pathlib import Path
+
+__all__ = [
+    "GF3DError",
+    "GF_OK",
+    "GF_SRC_FORCE",
+    "GF_SRC_CMT",
+    "GF_NCOMP",
+    "GF_NDP_MT",
+    "GF_NDP_LOC",
+    "CSource",
+    "CInfo",
+    "CStation",
+    "CLocation",
+    "CPlan",
+    "LIBRARY_LOCK",
+    "lib",
+    "library_path",
+    "check",
+]
+
+# ---------------------------------------------------------------------------
+# constants, from include/gf3d.h
+# ---------------------------------------------------------------------------
+
+GF3D_STRLEN = 64
+GF3D_MORTON_STRLEN = 24
+
+GF_OK = 0
+GF_ERR_NO_HDF5 = 1
+GF_ERR_NO_PATH = 2
+GF_ERR_NO_FILE = 3
+GF_ERR_HDF5 = 4
+GF_ERR_IO = 5
+GF_ERR_FORMAT = 6
+GF_ERR_MISMATCH = 7
+GF_ERR_INCOMPLETE = 8
+GF_ERR_ALLOC = 9
+GF_ERR_ARG = 10
+GF_ERR_NO_ELEMENT = 11
+GF_ERR_GEOMETRY = 12
+
+GF_SRC_FORCE = 1
+GF_SRC_CMT = 2
+
+GF_NCOMP = 3
+GF_NDP_MT = 6
+GF_NDP_LOC = 10
+
+_c_double = ctypes.c_double
+_c_int = ctypes.c_int
+_c_char = ctypes.c_char
+
+
+class GF3DError(Exception):
+    """A libgf3d call that did not return ``GF_OK``.
+
+    Carries the numeric code, the library's short name for it and the
+    message the library left behind, so that a caller can branch on
+    ``err.code`` (for instance ``GF_ERR_NO_ELEMENT`` when a trial source
+    wanders outside the database during an inversion) rather than parse
+    text.
+    """
+
+    def __init__(self, code: int, name: str, message: str):
+        self.code = code
+        self.name = name
+        self.message = message
+        super().__init__(f"{message} [{name}, code {code}]" if message else f"{name} (code {code})")
+
+
+# ---------------------------------------------------------------------------
+# the structures
+# ---------------------------------------------------------------------------
+
+
+class CSource(ctypes.Structure):
+    """``gf3d_source``"""
+
+    _fields_ = [
+        ("source_type", _c_int),
+        ("force_stf", _c_int),
+        ("latitude", _c_double),
+        ("longitude", _c_double),
+        ("depth_km", _c_double),
+        ("hdur", _c_double),
+        ("time_shift", _c_double),
+        ("moment", _c_double * 6),
+        ("force_factor", _c_double),
+        ("force_dir", _c_double * 3),
+    ]
+
+
+class CInfo(ctypes.Structure):
+    """``gf3d_info``"""
+
+    _fields_ = [
+        ("nelem", _c_int),
+        ("nstations", _c_int),
+        ("nstep", _c_int),
+        ("nt_subsampled", _c_int),
+        ("subsample_step", _c_int),
+        ("ngllx", _c_int),
+        ("nglly", _c_int),
+        ("ngllz", _c_int),
+        ("topography", _c_int),
+        ("ellipticity", _c_int),
+        ("rotation", _c_int),
+        ("attenuation", _c_int),
+        ("gravity", _c_int),
+        ("pad_", _c_int),
+        ("dt", _c_double),
+        ("t0", _c_double),
+        ("r_planet", _c_double),
+        ("rhoav", _c_double),
+        ("scale_displ", _c_double),
+    ]
+
+
+class CStation(ctypes.Structure):
+    """``gf3d_station``"""
+
+    _fields_ = [
+        ("id", _c_char * GF3D_STRLEN),
+        ("network", _c_char * GF3D_STRLEN),
+        ("station", _c_char * GF3D_STRLEN),
+        ("latitude", _c_double),
+        ("longitude", _c_double),
+        ("depth_m", _c_double),
+        ("hdur", _c_double),
+        ("f_cutoff", _c_double),
+        ("factor_force_source", _c_double),
+        ("time_shift", _c_double),
+    ]
+
+
+class CLocation(ctypes.Structure):
+    """``gf3d_location``"""
+
+    _fields_ = [
+        ("ielem", _c_int),
+        ("morton_hex", _c_char * GF3D_MORTON_STRLEN),
+        ("xi", _c_double),
+        ("eta", _c_double),
+        ("gamma", _c_double),
+        ("xyz", _c_double * 3),
+        ("xyz_target", _c_double * 3),
+        ("distance_km", _c_double),
+        ("anchor_err", _c_double),
+        ("theta", _c_double),
+        ("phi", _c_double),
+        ("r_surface", _c_double),
+    ]
+
+
+class CPlan(ctypes.Structure):
+    """``gf3d_plan``"""
+
+    _fields_ = [
+        ("nt", _c_int),
+        ("nt_db", _c_int),
+        ("npad", _c_int),
+        ("subsample_step", _c_int),
+        ("khalf", _c_int),
+        ("guard", _c_int),
+        ("kind_stf", _c_int),
+        ("pad_", _c_int),
+        ("dt", _c_double),
+        ("dt_sub", _c_double),
+        ("t0_db", _c_double),
+        ("t0_req", _c_double),
+        ("t0", _c_double),
+        ("t_first", _c_double),
+        ("hdur_src", _c_double),
+        ("hdur_target", _c_double),
+        ("hdur_db", _c_double),
+        ("hdur_corr", _c_double),
+        ("trunc", _c_double),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# finding the library
+# ---------------------------------------------------------------------------
+
+_HELP = """
+Could not load libgf3d.
+
+The library is built from a configured specfem3d_globe tree:
+
+    ./configure --with-hdf5 HDF5_INC=<dir> HDF5_LIBS=-L<dir>
+    make gf3d
+
+which writes lib/libgf3d.so. Point GF3D_LIB at it if it is somewhere this
+package cannot guess:
+
+    export GF3D_LIB=/path/to/specfem3d_globe/lib/libgf3d.so
+
+A load that fails naming libgfortran, libifcore, libmpi or libhdf5 means the
+library was found but the compiler's or HDF5's runtime is not on
+LD_LIBRARY_PATH: load the same modules the tree was built with.
+"""
+
+
+def _candidates():
+    env = os.environ.get("GF3D_LIB")
+    if env:
+        yield Path(env)
+
+    # utils/green_function/gf3d/_lib.py -> the repository root
+    root = Path(__file__).resolve().parents[3]
+    for name in ("libgf3d.so", "libgf3d.dylib"):
+        yield root / "lib" / name
+
+    found = ctypes.util.find_library("gf3d")
+    if found:
+        yield Path(found)
+
+
+def _load():
+    tried = []
+    for cand in _candidates():
+        if cand.exists() or not cand.is_absolute():
+            try:
+                return ctypes.CDLL(str(cand)), str(cand)
+            except OSError as exc:  # found but unloadable: say why
+                raise OSError(f"{cand}: {exc}\n{_HELP}") from exc
+        tried.append(str(cand))
+    raise OSError("looked in:\n  " + "\n  ".join(tried) + "\n" + _HELP)
+
+
+lib, library_path = _load()
+
+LIBRARY_LOCK = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# signatures
+# ---------------------------------------------------------------------------
+
+_c_double_p = ctypes.POINTER(_c_double)
+_c_int_p = ctypes.POINTER(_c_int)
+
+lib.gf3d_version.argtypes = [ctypes.c_char_p, _c_int]
+lib.gf3d_version.restype = _c_int
+
+lib.gf3d_sizeof.argtypes = [_c_int_p] * 5
+lib.gf3d_sizeof.restype = _c_int
+
+lib.gf3d_last_error.argtypes = [ctypes.c_char_p, _c_int]
+lib.gf3d_last_error.restype = _c_int
+
+lib.gf3d_error_string.argtypes = [_c_int, ctypes.c_char_p, _c_int]
+lib.gf3d_error_string.restype = _c_int
+
+lib.gf3d_open.argtypes = [ctypes.c_char_p, _c_int, _c_int_p]
+lib.gf3d_open.restype = _c_int
+
+lib.gf3d_close.argtypes = [_c_int]
+lib.gf3d_close.restype = _c_int
+
+lib.gf3d_get_info.argtypes = [_c_int, ctypes.POINTER(CInfo)]
+lib.gf3d_get_info.restype = _c_int
+
+lib.gf3d_get_station.argtypes = [_c_int, _c_int, ctypes.POINTER(CStation)]
+lib.gf3d_get_station.restype = _c_int
+
+lib.gf3d_locate.argtypes = [_c_int, _c_double, _c_double, _c_double, ctypes.POINTER(CLocation)]
+lib.gf3d_locate.restype = _c_int
+
+lib.gf3d_get_plan.argtypes = [_c_int, ctypes.POINTER(CSource), _c_double, ctypes.POINTER(CPlan)]
+lib.gf3d_get_plan.restype = _c_int
+
+lib.gf3d_ndp.argtypes = [_c_int, _c_int_p]
+lib.gf3d_ndp.restype = _c_int
+
+lib.gf3d_partial_name.argtypes = [_c_int, ctypes.c_char_p, _c_int, ctypes.c_char_p, _c_int]
+lib.gf3d_partial_name.restype = _c_int
+
+lib.gf3d_seismograms.argtypes = [
+    _c_int,
+    ctypes.POINTER(CSource),
+    _c_double,
+    _c_int,
+    _c_double_p,
+    _c_double_p,
+    _c_double_p,
+    ctypes.POINTER(CLocation),
+]
+lib.gf3d_seismograms.restype = _c_int
+
+lib.gf3d_partials.argtypes = [
+    _c_int,
+    ctypes.POINTER(CSource),
+    _c_double,
+    _c_int,
+    _c_int,
+    _c_int,
+    _c_double_p,
+    _c_double_p,
+    _c_double_p,
+    _c_double_p,
+    ctypes.POINTER(CLocation),
+]
+lib.gf3d_partials.restype = _c_int
+
+
+# ---------------------------------------------------------------------------
+# layout check
+# ---------------------------------------------------------------------------
+
+
+def _check_layout():
+    sizes = [_c_int() for _ in range(5)]
+    lib.gf3d_sizeof(*[ctypes.byref(s) for s in sizes])
+    expected = [CSource, CInfo, CStation, CLocation, CPlan]
+    for got, cls in zip(sizes, expected):
+        if got.value != ctypes.sizeof(cls):
+            raise RuntimeError(
+                f"{cls.__name__} is {ctypes.sizeof(cls)} bytes here but "
+                f"{got.value} in {library_path}: this package and the library "
+                "were built from different versions of include/gf3d.h"
+            )
+
+
+_check_layout()
+
+
+# ---------------------------------------------------------------------------
+# errors
+# ---------------------------------------------------------------------------
+
+
+def check(code: int, context: str = "") -> None:
+    """Raise :class:`GF3DError` unless ``code`` is ``GF_OK``.
+
+    Must be called with ``LIBRARY_LOCK`` still held: the message it reads is
+    process-wide, so another thread's failure would otherwise be reported
+    here.
+    """
+    if code == GF_OK:
+        return
+
+    name_buf = ctypes.create_string_buffer(64)
+    msg_buf = ctypes.create_string_buffer(512)
+    lib.gf3d_error_string(code, name_buf, len(name_buf))
+    lib.gf3d_last_error(msg_buf, len(msg_buf))
+
+    message = msg_buf.value.decode("utf-8", "replace").strip()
+    if context:
+        message = f"{context}: {message}" if message else context
+    raise GF3DError(code, name_buf.value.decode("utf-8", "replace").strip(), message)
+
+
+def version() -> str:
+    """The library's own version string."""
+    buf = ctypes.create_string_buffer(64)
+    with LIBRARY_LOCK:
+        lib.gf3d_version(buf, len(buf))
+    return buf.value.decode("utf-8", "replace")

--- a/utils/green_function/gf3d/_lib.py
+++ b/utils/green_function/gf3d/_lib.py
@@ -265,7 +265,17 @@ def _load():
 
 lib, library_path = _load()
 
-LIBRARY_LOCK = threading.Lock()
+# Reentrant on purpose. The lock serialises calls into a library that keeps
+# process-wide state, and that is all it is for -- but the wrapper's own
+# properties compose (Database.stations needs Database.info, and either may
+# have to call the library), and under a plain Lock any such nesting is a
+# deadlock. One existed: Database.stations resolved nstations inside the
+# lock, so asking a fresh database for its stations before anything had
+# read its info hung the interpreter. That call is now hoisted out, and
+# this is reentrant so that the next composition of two locked properties
+# is merely slow to write rather than fatal to run. An RLock still
+# serialises across threads, which is the property that matters.
+LIBRARY_LOCK = threading.RLock()
 
 
 # ---------------------------------------------------------------------------

--- a/utils/green_function/gf3d/database.py
+++ b/utils/green_function/gf3d/database.py
@@ -1,0 +1,447 @@
+"""The database handle and what comes out of it."""
+
+from __future__ import annotations
+
+import ctypes
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+
+from . import _lib
+from ._lib import (
+    CInfo,
+    CLocation,
+    CPlan,
+    CStation,
+    GF_NCOMP,
+    GF_NDP_LOC,
+    GF_NDP_MT,
+    GF3DError,
+    LIBRARY_LOCK,
+    check,
+    lib,
+)
+from .sources import CMTSource, ForceSource
+
+__all__ = ["Database", "Result", "Plan", "Location", "Station", "open"]
+
+_ONSET_WARN = 1.0e-3
+_DOUBLE_P = ctypes.POINTER(ctypes.c_double)
+
+
+def _ptr(a: np.ndarray):
+    return a.ctypes.data_as(_DOUBLE_P)
+
+
+def _s(b: bytes) -> str:
+    return b.decode("utf-8", "replace").strip()
+
+
+@dataclass(frozen=True)
+class Station:
+    """One reciprocal station of a database."""
+
+    id: str
+    network: str
+    station: str
+    latitude: float
+    longitude: float
+    depth_m: float
+    hdur: float
+    f_cutoff: float
+    factor_force_source: float
+    time_shift: float
+
+    @classmethod
+    def _from_c(cls, c: CStation) -> "Station":
+        return cls(
+            id=_s(c.id), network=_s(c.network), station=_s(c.station),
+            latitude=c.latitude, longitude=c.longitude, depth_m=c.depth_m,
+            hdur=c.hdur, f_cutoff=c.f_cutoff,
+            factor_force_source=c.factor_force_source, time_shift=c.time_shift,
+        )
+
+
+@dataclass(frozen=True)
+class Location:
+    """Where a source sits in the mesh."""
+
+    ielem: int
+    morton_hex: str
+    xi: float
+    eta: float
+    gamma: float
+    xyz: tuple
+    xyz_target: tuple
+    distance_km: float
+    anchor_err: float
+    theta: float
+    phi: float
+    r_surface: float
+
+    @classmethod
+    def _from_c(cls, c: CLocation) -> "Location":
+        return cls(
+            ielem=c.ielem, morton_hex=_s(c.morton_hex),
+            xi=c.xi, eta=c.eta, gamma=c.gamma,
+            xyz=tuple(c.xyz), xyz_target=tuple(c.xyz_target),
+            distance_km=c.distance_km, anchor_err=c.anchor_err,
+            theta=c.theta, phi=c.phi, r_surface=c.r_surface,
+        )
+
+
+@dataclass(frozen=True)
+class Plan:
+    """The output time axis and the source time function conversion.
+
+    ``nt`` is the length of everything an extraction returns, and
+    ``t_first`` its first sample, in seconds relative to the centroid time.
+    ``guard`` is set when the requested source is narrower than the one the
+    database was built with, in which case no width correction is possible
+    and the traces carry the database's own duration.
+    """
+
+    nt: int
+    nt_db: int
+    npad: int
+    subsample_step: int
+    khalf: int
+    guard: bool
+    kind_stf: int
+    dt: float
+    dt_sub: float
+    t0_db: float
+    t0_req: float
+    t0: float
+    t_first: float
+    hdur_src: float
+    hdur_target: float
+    hdur_db: float
+    hdur_corr: float
+    trunc: float
+
+    @classmethod
+    def _from_c(cls, c: CPlan) -> "Plan":
+        return cls(
+            nt=c.nt, nt_db=c.nt_db, npad=c.npad, subsample_step=c.subsample_step,
+            khalf=c.khalf, guard=bool(c.guard), kind_stf=c.kind_stf,
+            dt=c.dt, dt_sub=c.dt_sub, t0_db=c.t0_db, t0_req=c.t0_req, t0=c.t0,
+            t_first=c.t_first, hdur_src=c.hdur_src, hdur_target=c.hdur_target,
+            hdur_db=c.hdur_db, hdur_corr=c.hdur_corr, trunc=c.trunc,
+        )
+
+    @property
+    def times(self) -> np.ndarray:
+        """The axis, as the library builds it."""
+        return self.t_first + np.arange(self.nt) * self.dt_sub
+
+
+@dataclass
+class Result:
+    """Seismograms, and optionally their partial derivatives.
+
+    ``data`` has shape ``(nstations, 3, nt)`` in metres, components N, E, Z,
+    with ``t`` the shared time axis in seconds relative to the centroid
+    time. ``dp``, when present, has shape ``(nstations, ndp, 3, nt)`` with
+    the partials in the order named by ``dp_names``: the six moment-tensor
+    components per dyne-cm, then latitude and longitude per degree, depth
+    per km and centroid time per second.
+
+    So ``(result.dp[:, :6] * cmt.tensor[None, :, None, None]).sum(1)``
+    reproduces ``result.data``: the partials are exact and linear, not
+    finite differences.
+    """
+
+    t: np.ndarray
+    data: np.ndarray
+    onset: np.ndarray
+    plan: Plan
+    station_ids: list
+    location: Location | None = None
+    dp: np.ndarray | None = None
+    dp_names: list | None = None
+    dp_units: list | None = None
+    source: object = None
+
+    @property
+    def nt(self) -> int:
+        return self.data.shape[2]
+
+    @property
+    def nstations(self) -> int:
+        return self.data.shape[0]
+
+    def trace(self, station, component: str) -> np.ndarray:
+        """One trace by station id (or index) and component name."""
+        ista = self.station_ids.index(station) if isinstance(station, str) else station
+        icomp = "NEZ".index(component.upper())
+        return self.data[ista, icomp]
+
+    def partial(self, station, component: str, name: str) -> np.ndarray:
+        """One partial derivative by name, e.g. ``"Mrr"`` or ``"dep"``."""
+        if self.dp is None:
+            raise ValueError("this result carries no partial derivatives")
+        ista = self.station_ids.index(station) if isinstance(station, str) else station
+        icomp = "NEZ".index(component.upper())
+        return self.dp[ista, self.dp_names.index(name), icomp]
+
+    def to_stream(self):
+        """An obspy :class:`~obspy.core.stream.Stream` of the seismograms.
+
+        obspy is an optional dependency; this is the only thing that needs
+        it. Channels follow the solver's own naming, ``BXN``/``BXE``/``BXZ``,
+        and the start time is the centroid time plus ``t[0]`` when the
+        source carried an origin time.
+        """
+        from obspy import Stream, Trace, UTCDateTime  # noqa: PLC0415
+        from obspy.core.trace import Stats  # noqa: PLC0415
+
+        centroid = getattr(self.source, "centroid_time", None)
+        traces = []
+        for ista, sid in enumerate(self.station_ids):
+            net, _, sta = sid.partition(".")
+            for icomp, comp in enumerate("NEZ"):
+                stats = Stats()
+                stats.network = net
+                stats.station = sta
+                stats.channel = f"BX{comp}"
+                stats.location = ""
+                stats.delta = self.plan.dt_sub
+                if centroid is not None:
+                    stats.starttime = UTCDateTime(centroid) + float(self.t[0])
+                else:
+                    stats.starttime = UTCDateTime(0) + float(self.t[0])
+                traces.append(Trace(data=self.data[ista, icomp].copy(), header=stats))
+        return Stream(traces)
+
+
+class Database:
+    """An open Green function database.
+
+    Use it as a context manager, or call :meth:`close` when done::
+
+        with gf3d.Database("EXAMPLES/.../regional/GFDB") as db:
+            r = db.partials(gf3d.CMTSource.read("CMTSOLUTION"))
+
+    Opening reads the metadata only; the 58 MB topography grid and the
+    element files are read on demand, so the cost of an open is small and
+    the cost of the first extraction is not.
+
+    Two databases may be open at once, but the search tree is rebuilt
+    whenever an extraction switches between them, so alternating is slow --
+    and two databases of *different planets or topography grids* must not be
+    used alternately at all, since specfem's globals hold one set of
+    dimensions for the process.
+    """
+
+    def __init__(self, path, check_completion: bool = False):
+        self.path = str(path)
+        self._handle = ctypes.c_int(0)
+        self._info = None
+
+        with LIBRARY_LOCK:
+            code = lib.gf3d_open(
+                self.path.encode(), 1 if check_completion else 0, ctypes.byref(self._handle)
+            )
+            check(code, f"opening {self.path}")
+
+    # -- lifetime ---------------------------------------------------------
+
+    @property
+    def closed(self) -> bool:
+        return self._handle.value == 0
+
+    def close(self) -> None:
+        """Close the database and release the search tree. Idempotent."""
+        if self.closed:
+            return
+        h, self._handle.value = self._handle.value, 0
+        with LIBRARY_LOCK:
+            lib.gf3d_close(h)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def __del__(self):
+        # interpreter teardown can have unloaded ctypes already
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def __repr__(self):
+        if self.closed:
+            return f"<gf3d.Database {self.path!r} (closed)>"
+        return (
+            f"<gf3d.Database {self.path!r}: {self.info['nstations']} stations, "
+            f"{self.info['nelem']} elements, {self.info['nt_subsampled']} samples>"
+        )
+
+    def _h(self) -> int:
+        if self.closed:
+            raise GF3DError(_lib.GF_ERR_ARG, "invalid argument", "the database is closed")
+        return self._handle.value
+
+    # -- metadata ---------------------------------------------------------
+
+    @property
+    def info(self) -> dict:
+        """What the database says about itself."""
+        if self._info is None:
+            c = CInfo()
+            with LIBRARY_LOCK:
+                check(lib.gf3d_get_info(self._h(), ctypes.byref(c)), "gf3d_get_info")
+            d = {f: getattr(c, f) for f, _ in CInfo._fields_ if f != "pad_"}
+            for flag in ("topography", "ellipticity", "rotation", "attenuation", "gravity"):
+                d[flag] = bool(d[flag])
+            self._info = d
+        return self._info
+
+    @property
+    def stations(self) -> list:
+        """Every station, in the library's own order."""
+        out = []
+        c = CStation()
+        with LIBRARY_LOCK:
+            h = self._h()
+            for i in range(self.info["nstations"]):
+                check(lib.gf3d_get_station(h, i, ctypes.byref(c)), f"station {i}")
+                out.append(Station._from_c(c))
+        return out
+
+    @property
+    def station_ids(self) -> list:
+        """``['NET.STA', ...]``, the first axis of every extracted array."""
+        return [s.id for s in self.stations]
+
+    # -- locating and planning -------------------------------------------
+
+    def locate(self, latitude: float, longitude: float, depth_km: float) -> Location:
+        """Find the element containing a geographic point."""
+        c = CLocation()
+        with LIBRARY_LOCK:
+            check(
+                lib.gf3d_locate(self._h(), latitude, longitude, depth_km, ctypes.byref(c)),
+                f"locating {latitude}, {longitude} at {depth_km} km",
+            )
+        return Location._from_c(c)
+
+    def plan(self, source, t0: float | None = None) -> Plan:
+        """The output axis and conversion for a source, without extracting."""
+        c = CPlan()
+        csrc = source._to_struct()
+        with LIBRARY_LOCK:
+            check(
+                lib.gf3d_get_plan(
+                    self._h(), ctypes.byref(csrc), -1.0 if t0 is None else float(t0),
+                    ctypes.byref(c),
+                ),
+                "gf3d_get_plan",
+            )
+        return Plan._from_c(c)
+
+    # -- extraction -------------------------------------------------------
+
+    def seismograms(self, source, t0: float | None = None) -> Result:
+        """Seismograms at every station.
+
+        ``t0`` is the start time in seconds before the centroid time; the
+        default is specfem's own rule for a forward run, 1.5 times the half
+        duration for a moment tensor.
+        """
+        return self._extract(source, t0, itypsokern=0)
+
+    def partials(self, source, kind: int = 2, t0: float | None = None) -> Result:
+        """Seismograms and their partial derivatives.
+
+        ``kind=1`` gives the six moment-tensor partials, ``kind=2`` those
+        plus latitude, longitude, depth and centroid time. A force source
+        has none.
+        """
+        if kind not in (1, 2):
+            raise ValueError("kind must be 1 (moment tensor) or 2 (and centroid)")
+        return self._extract(source, t0, itypsokern=kind)
+
+    def _extract(self, source, t0, itypsokern: int) -> Result:
+        csrc = source._to_struct()
+        t0_req = -1.0 if t0 is None else float(t0)
+
+        plan = self.plan(source, t0)
+        nt = plan.nt
+        nsta = self.info["nstations"]
+        ids = self.station_ids
+
+        ndp = 0
+        if itypsokern > 0:
+            n = ctypes.c_int(0)
+            with LIBRARY_LOCK:
+                check(lib.gf3d_ndp(itypsokern, ctypes.byref(n)), "gf3d_ndp")
+            ndp = n.value
+
+        seis = np.empty((nsta, GF_NCOMP, nt), dtype=np.float64)
+        t = np.empty(nt, dtype=np.float64)
+        onset = np.empty(nsta, dtype=np.float64)
+        dp = np.empty((nsta, ndp, GF_NCOMP, nt), dtype=np.float64) if ndp else None
+        cloc = CLocation()
+
+        with LIBRARY_LOCK:
+            h = self._h()
+            if ndp:
+                code = lib.gf3d_partials(
+                    h, ctypes.byref(csrc), t0_req, itypsokern, nt, ndp,
+                    _ptr(seis), _ptr(dp), _ptr(t), _ptr(onset), ctypes.byref(cloc),
+                )
+            else:
+                code = lib.gf3d_seismograms(
+                    h, ctypes.byref(csrc), t0_req, nt,
+                    _ptr(seis), _ptr(t), _ptr(onset), ctypes.byref(cloc),
+                )
+            check(code, "extraction")
+
+        names = units = None
+        if ndp:
+            names, units = self.partial_names(ndp)
+
+        worst = float(onset.max()) if nsta else 0.0
+        if worst > _ONSET_WARN:
+            warnings.warn(
+                f"the record starts with {worst:.2e} of the trace peak already "
+                "present: the source time function conversion is reaching back "
+                "past the beginning of the stored record, so the first arrivals "
+                "may be contaminated. A longer reciprocal run, or a later t0, "
+                "is the cure.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+        return Result(
+            t=t, data=seis, onset=onset, plan=plan, station_ids=ids,
+            location=Location._from_c(cloc), dp=dp, dp_names=names,
+            dp_units=units, source=source,
+        )
+
+    @staticmethod
+    def partial_names(ndp: int = GF_NDP_LOC):
+        """``(names, units)`` of the first ``ndp`` partials."""
+        names, units = [], []
+        nbuf = ctypes.create_string_buffer(16)
+        ubuf = ctypes.create_string_buffer(16)
+        with LIBRARY_LOCK:
+            for ip in range(ndp):
+                check(
+                    lib.gf3d_partial_name(ip, nbuf, len(nbuf), ubuf, len(ubuf)),
+                    f"partial {ip}",
+                )
+                names.append(_s(nbuf.value))
+                units.append(_s(ubuf.value))
+        return names, units
+
+
+def open(path, check_completion: bool = False) -> Database:  # noqa: A001
+    """Open a database. The same as calling :class:`Database`."""
+    return Database(path, check_completion=check_completion)

--- a/utils/green_function/gf3d/database.py
+++ b/utils/green_function/gf3d/database.py
@@ -305,11 +305,15 @@ class Database:
     @property
     def stations(self) -> list:
         """Every station, in the library's own order."""
+        # resolved before the lock is taken, not inside the loop: self.info
+        # may itself have to call the library
+        nstations = self.info["nstations"]
+
         out = []
         c = CStation()
         with LIBRARY_LOCK:
             h = self._h()
-            for i in range(self.info["nstations"]):
+            for i in range(nstations):
                 check(lib.gf3d_get_station(h, i, ctypes.byref(c)), f"station {i}")
                 out.append(Station._from_c(c))
         return out

--- a/utils/green_function/gf3d/sources.py
+++ b/utils/green_function/gf3d/sources.py
@@ -1,0 +1,219 @@
+"""Seismic sources, and how to read them from specfem's own files.
+
+Parsing happens here, in Python, and not in the library. That is deliberate:
+reading a CMTSOLUTION in Fortran means ``get_cmt()``, which ends the process
+on malformed input, and a ``stop`` inside a shared object takes the
+interpreter with it. So the C API takes numbers, and turning a file into
+numbers is this module's job -- where a bad file is a ``ValueError`` with a
+line number.
+
+Both readers follow the format the solver reads: one ``name: value`` per
+line, in a fixed order, with the value being whatever follows the last
+colon. Fortran ``d`` exponents (``1.0d15``) are accepted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ._lib import CSource, GF_SRC_CMT, GF_SRC_FORCE
+
+__all__ = ["CMTSource", "ForceSource"]
+
+
+def _to_float(text: str, where: str) -> float:
+    """A float, accepting Fortran's d exponent."""
+    cleaned = text.strip().replace("d", "e").replace("D", "E")
+    try:
+        return float(cleaned)
+    except ValueError:
+        raise ValueError(f"{where}: expected a number, got {text.strip()!r}") from None
+
+
+def _value(line: str, where: str) -> str:
+    """Everything after the last colon."""
+    if ":" not in line:
+        raise ValueError(f"{where}: expected 'name: value', got {line.strip()!r}")
+    return line.rsplit(":", 1)[1]
+
+
+def _lines(path, nexpected: int, kind: str) -> list[str]:
+    path = Path(path)
+    try:
+        raw = path.read_text().splitlines()
+    except OSError as exc:
+        raise ValueError(f"cannot read {kind} {path}: {exc}") from None
+    if len(raw) < nexpected:
+        raise ValueError(
+            f"{path}: a {kind} has {nexpected} lines, this one has {len(raw)}"
+        )
+    return raw
+
+
+@dataclass
+class CMTSource:
+    """A moment-tensor (centroid) source.
+
+    Field names and units are the CMTSOLUTION's own: degrees, kilometres,
+    seconds, and dyne-cm for the moment tensor. ``hdur`` is the *triangle*
+    half duration as the file writes it; the Gaussian width specfem actually
+    uses is ``hdur/1.628``, and the library applies that itself.
+
+    ``time_shift`` is metadata. The traces returned by this package have
+    ``t = 0`` at the centroid time, so the shift belongs in an absolute
+    start time and never in the trace.
+    """
+
+    latitude: float = 0.0
+    longitude: float = 0.0
+    depth: float = 0.0
+    """Centroid depth, km."""
+    hdur: float = 0.0
+    time_shift: float = 0.0
+    Mrr: float = 0.0
+    Mtt: float = 0.0
+    Mpp: float = 0.0
+    Mrt: float = 0.0
+    Mrp: float = 0.0
+    Mtp: float = 0.0
+    origin_time: datetime | None = None
+    """The PDE line's time, if the file carried one."""
+    event_name: str = ""
+    region: str = ""
+
+    @property
+    def tensor(self) -> tuple:
+        """``(Mrr, Mtt, Mpp, Mrt, Mrp, Mtp)`` in dyne-cm, the order the
+        moment-tensor partials come back in."""
+        return (self.Mrr, self.Mtt, self.Mpp, self.Mrt, self.Mrp, self.Mtp)
+
+    @property
+    def centroid_time(self) -> datetime | None:
+        """``origin_time + time_shift``: the instant ``t = 0`` refers to."""
+        if self.origin_time is None:
+            return None
+        from datetime import timedelta
+
+        return self.origin_time + timedelta(seconds=self.time_shift)
+
+    @classmethod
+    def read(cls, path) -> "CMTSource":
+        """Read a 13-line CMTSOLUTION."""
+        raw = _lines(path, 13, "CMTSOLUTION")
+        src = cls()
+
+        # the PDE header: fixed columns, not name: value
+        pde = raw[0].split()
+        if len(pde) >= 7:
+            try:
+                year, month, day = int(pde[1]), int(pde[2]), int(pde[3])
+                hour, minute = int(pde[4]), int(pde[5])
+                second = float(pde[6])
+                whole = int(second)
+                src.origin_time = datetime(
+                    year, month, day, hour, minute, whole,
+                    int(round((second - whole) * 1e6)), tzinfo=timezone.utc,
+                )
+            except (ValueError, IndexError):
+                src.origin_time = None  # a header we do not recognise is not fatal
+            src.region = " ".join(pde[12:]) if len(pde) > 12 else ""
+
+        src.event_name = _value(raw[1], f"{path}:2").strip()
+        src.time_shift = _to_float(_value(raw[2], f"{path}:3"), f"{path}:3")
+        src.hdur = _to_float(_value(raw[3], f"{path}:4"), f"{path}:4")
+        src.latitude = _to_float(_value(raw[4], f"{path}:5"), f"{path}:5")
+        src.longitude = _to_float(_value(raw[5], f"{path}:6"), f"{path}:6")
+        src.depth = _to_float(_value(raw[6], f"{path}:7"), f"{path}:7")
+        for i, name in enumerate(("Mrr", "Mtt", "Mpp", "Mrt", "Mrp", "Mtp")):
+            setattr(src, name, _to_float(_value(raw[7 + i], f"{path}:{8+i}"), f"{path}:{8+i}"))
+
+        return src
+
+    def _to_struct(self) -> CSource:
+        c = CSource()
+        c.source_type = GF_SRC_CMT
+        c.force_stf = 0
+        c.latitude = self.latitude
+        c.longitude = self.longitude
+        c.depth_km = self.depth
+        c.hdur = self.hdur
+        c.time_shift = self.time_shift
+        for i, v in enumerate(self.tensor):
+            c.moment[i] = v
+        c.force_factor = 0.0
+        for i in range(3):
+            c.force_dir[i] = 0.0
+        return c
+
+
+@dataclass
+class ForceSource:
+    """A point-force source.
+
+    ``f0`` is the FORCESOLUTION's own field: a dominant frequency for a
+    Ricker (``stf = 1``), a width otherwise. ``factor`` is in Newtons and
+    ``direction`` is ``(E, N, Z_up)`` of arbitrary length -- the magnitude
+    lives entirely in ``factor``.
+    """
+
+    latitude: float = 0.0
+    longitude: float = 0.0
+    depth: float = 0.0
+    """Source depth, km."""
+    f0: float = 0.0
+    time_shift: float = 0.0
+    stf: int = 0
+    """0 Gaussian, 1 Ricker, 2 step, 3 monochromatic, 4 Gaussian (Meschede)."""
+    factor: float = 1.0e15
+    """Newtons."""
+    direction: tuple = (0.0, 0.0, 1.0)
+    """(E, N, Z up)."""
+    label: str = ""
+
+    @classmethod
+    def read(cls, path) -> "ForceSource":
+        """Read an 11-line FORCESOLUTION.
+
+        Accepts both the globe's spelling (``f0:``, ``comp dir vect source
+        Z:``) and the Cartesian package's (``half duration:``, ``...
+        Z_UP:``): every line is read by position, and only the value after
+        the last colon is used, so the two differ in nothing that matters
+        here.
+        """
+        raw = _lines(path, 11, "FORCESOLUTION")
+        src = cls()
+
+        first = raw[0].split()
+        src.label = first[-1] if len(first) > 1 else ""
+
+        src.time_shift = _to_float(_value(raw[1], f"{path}:2"), f"{path}:2")
+        src.f0 = _to_float(_value(raw[2], f"{path}:3"), f"{path}:3")
+        src.latitude = _to_float(_value(raw[3], f"{path}:4"), f"{path}:4")
+        src.longitude = _to_float(_value(raw[4], f"{path}:5"), f"{path}:5")
+        src.depth = _to_float(_value(raw[5], f"{path}:6"), f"{path}:6")
+        src.stf = int(_to_float(_value(raw[6], f"{path}:7"), f"{path}:7"))
+        src.factor = _to_float(_value(raw[7], f"{path}:8"), f"{path}:8")
+        src.direction = (
+            _to_float(_value(raw[8], f"{path}:9"), f"{path}:9"),
+            _to_float(_value(raw[9], f"{path}:10"), f"{path}:10"),
+            _to_float(_value(raw[10], f"{path}:11"), f"{path}:11"),
+        )
+        return src
+
+    def _to_struct(self) -> CSource:
+        c = CSource()
+        c.source_type = GF_SRC_FORCE
+        c.force_stf = int(self.stf)
+        c.latitude = self.latitude
+        c.longitude = self.longitude
+        c.depth_km = self.depth
+        c.hdur = self.f0
+        c.time_shift = self.time_shift
+        for i in range(6):
+            c.moment[i] = 0.0
+        c.force_factor = self.factor
+        for i in range(3):
+            c.force_dir[i] = self.direction[i]
+        return c

--- a/utils/green_function/gf_sac_check.py
+++ b/utils/green_function/gf_sac_check.py
@@ -46,6 +46,34 @@ except ImportError:  # pragma: no cover - the runner skips before this
 
 COMPONENTS = "NEZ"
 
+# The single-precision row of testing.md's tolerance table, applied to the
+# stored data relative to the trace's own peak.
+#
+# Not bitwise, and the reason is a real difference between compilers rather
+# than a slack tolerance. The Intel builds carry -ftz (flags.guess:104,115),
+# so the writer's real(x) flushes a subnormal to zero where numpy's
+# float32() keeps it. On the moment-tensor partials, whose values are ~1e-32
+# per dyne-cm, three dozen samples per trace are subnormal, and under ifx
+# every one of them differs -- by 1e-7 of the trace peak, which is nothing,
+# while a shifted sample or a swapped component would be a whole peak.
+#
+# The same rule was applied to the tier-1 re-read in test_gf_sac.f90 after
+# the Intel CI failed it; this is the tier-2 half of it. See testing.md.
+SINGLE_TOL = 1.0e-6
+
+
+def data_error(stored, expected):
+    """Largest difference between two single-precision traces, relative to
+    the peak of the expected one."""
+    stored = np.asarray(stored, dtype=np.float64)
+    expected = np.asarray(expected, dtype=np.float64)
+    if stored.shape != expected.shape:
+        return np.inf
+    peak = np.abs(expected).max()
+    if peak == 0.0:
+        return float(np.abs(stored).max())
+    return float(np.abs(stored - expected).max() / peak)
+
 
 class Checker:
     def __init__(self):
@@ -122,10 +150,12 @@ def main():
                       f"{station}.{chan}: b = t_first ({h.b} vs {plan['t_first']})")
             chk.check(h.o == 0.0, f"{station}.{chan}: o = 0")
 
-            # the data, single precision, exactly
+            # the data, at the single-precision row
             col = traces[comp].astype(np.float32)
-            chk.check(tr.data.dtype == np.float32 and np.array_equal(tr.data, col),
-                      f"{station}.{chan}: data equal the ASCII column in single precision")
+            err = data_error(tr.data, col)
+            chk.check(tr.data.dtype == np.float32 and err <= SINGLE_TOL,
+                      f"{station}.{chan}: data equal the ASCII column in single precision "
+                      f"({err:.2e})")
 
             # the forward run's headers
             fsac = os.path.join(args.fwd, f"{station}.{chan}.sem.sac")
@@ -157,8 +187,9 @@ def main():
                     chk.check(False, f"{station}.{chan}.{name}: obspy read failed: {exc}")
                     continue
                 ph = ptr.stats.sac
-                chk.check(np.array_equal(ptr.data, pcols[(comp, name)].astype(np.float32)),
-                          f"{station}.{chan}.{name}: data equal the partials column")
+                perr = data_error(ptr.data, pcols[(comp, name)].astype(np.float32))
+                chk.check(perr <= SINGLE_TOL,
+                          f"{station}.{chan}.{name}: data equal the partials column ({perr:.2e})")
                 chk.check(str(ph.kuser1).strip() == name, f"{station}.{chan}.{name}: kuser1 = {name}")
                 same = all(getattr(ph, k) == getattr(h, k) for k in
                            ("b", "delta", "npts", "o", "nzyear", "nzjday", "nzhour", "nzmin", "nzsec",

--- a/utils/green_function/pyproject.toml
+++ b/utils/green_function/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gf3d"
+version = "0.1.0"
+description = "Green function extraction from a specfem3d_globe reciprocal database"
+requires-python = ">=3.10"
+license = { text = "GPL-3.0-or-later" }
+# numpy only: the package is a ctypes binding, so there is nothing to
+# compile at install time and no build backend to depend on. obspy is
+# needed by Result.to_stream() alone.
+dependencies = ["numpy>=1.22"]
+
+[project.optional-dependencies]
+obspy = ["obspy>=1.4"]
+
+[tool.setuptools]
+packages = ["gf3d"]


### PR DESCRIPTION
**Title:** gf3d: public API, C binding and Python module (PR 4)

This PR makes the extraction library of #883 and #884 callable from
somewhere other than the command line, for source inversion: seismograms
and their ten partial derivatives in memory, with no process launch and no
SAC file per iteration.

`make gf3d` now also produces `lib/libgf3d.so`, `include/gf3d.h` and
`include/gf3d.mod`. `bin/xgf3d` and `lib/libgf3d.a` are unchanged, and
`xgf3d --seis --format ascii` is byte-identical to #884 on all 14 station
files of both examples.

**Python** — a ctypes binding, so no compiler and numpy the only
dependency:

```python
import gf3d

with gf3d.Database("GFDB") as db:
    cmt = gf3d.CMTSource.read("CMTSOLUTION")

    r = db.seismograms(cmt)   # r.data (nsta, 3, nt) metres, r.t (nt,) seconds
    r = db.partials(cmt)      # and r.dp (nsta, 10, 3, nt)
```

**Fortran** — `use gf3d` and nothing else:

```fortran
use gf3d

type(t_gfdb) :: db
type(t_gf_source) :: src
double precision, dimension(:,:,:), allocatable :: synt
double precision, dimension(:,:,:,:), allocatable :: dp
double precision, dimension(:), allocatable :: t
integer :: ierr

call gf_open('GFDB',db,ierr)
call gf_read_cmt_source('CMTSOLUTION',db%dt,src,ierr)

call get_seismograms(db,src,synt,dp,2,t,ierr)  ! synt(nsta,3,nt), dp(10,nsta,3,nt)

call gf_release(db)
```

linked with `-I include -L lib -lgf3d` and an rpath — no HDF5 flags, since
the shared object carries its own dependencies. `include/gf3d.h` is the same
API for C.

The partials are analytic and per dyne-cm, degree, km and second, so
`Σ M_v·dp(v)` with the CMTSOLUTION's own numbers reproduces the seismogram.

**Design notes.** Nothing reachable through the C ABI can end the process,
which is what a `stop` inside a `.so` would do to a Python interpreter. Two
consequences: the handle is an index into a table rather than a pointer, so
a stale one is a bounds test; and the API takes source *values*, never a
file path, because reading one means `get_cmt`/`get_force` and their `stop`
statements. `gf_source_set_cmt`/`_force` apply those readers' own post-parse
arithmetic instead. Every real crossing the boundary is screened for
finiteness — a NaN latitude otherwise reaches the kd-tree's own `stop`.

**Validation** — the oracles are the library reached another way and the
executable's own output; nothing here recomputes a seismogram.

| check | result |
|---|---|
| Python vs `xgf3d --seis --format ascii`, every station and the axis | 0 |
| C route vs the Fortran module: seismograms and all ten partials, both source types | 0 |
| `Σ M_v·dp(v)` vs the seismogram, through the C ABI | 1.5e-15 |
| the values route vs `get_cmt`/`get_force`, every field | 0 |
| `ldd lib/libgf3d.so` with `LD_LIBRARY_PATH` unset | HDF5 resolved through the rpath |

Eighteen deliberate mistakes — bad handles, a wrong `nt`, a NaN, partials of
a force source — each return an error code with the process alive.

**Tests**: `tests/gf3d/`, eighteen runners, four new. `test_gf_source` pins
the values route against the solver's readers; `test_gf_capi` is the first
test in the tree written in C; `test_gf3d_ext` builds against `include/` and
`lib/libgf3d.a` alone, which is what makes "the public module is enough" a
checked claim; `test_gf_python` compares the package against `xgf3d`. Green
under gfortran 14, ifort 2021.10, ifort 2021.13 and ifx 2024.2.

**Examples**: `EXAMPLES/green_function_database/global/api_demos/` holds four
short runnable programs, two per language, outside the workflow. They
extract, check the linearity identity, and then use a centroid partial as a
derivative — predicting a relocated source from one Taylor term and showing
the error fall fourfold as the step halves.

**Scope**: `src/gf3d/`, `tests/gf3d/`, `utils/green_function/`, `EXAMPLES/`,
and in `Makefile.in` three variable definitions plus one line of `help`. No
solver or shared code changes.

**Also**: `gf_sac_check.py` compared SAC data bitwise, which fails under ifx
(`-ftz` flushes a subnormal to zero where numpy keeps it, and the
moment-tensor partials are ~1e-32 per dyne-cm). It now asserts the
single-precision row relative to the trace peak, as `test_gf_sac.f90` does.
And the Python wrapper deadlocked when a fresh database was asked for its
stations before its metadata — a lock held across a call into its own API,
hidden by every existing caller happening to ask in the other order.

**Not in this PR**: the comparison harness reading SAC, and the removal of
the old Python extraction — PR 5, parallel to this one.

The code is planned by @lsawade and written by Claude Code.

---

The final, coming PR will be a clean-up of the prior 4 PRs. 

- Remove references to the reference GF3DF: https://github.com/lsawade/GF3DF/
- Remove references to the planning phase (stages, etc.)
- Critically reviewing the example workflows
- Critically reviewing test design for redundancies, questionable testing choice